### PR TITLE
String trim native method

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,6 +12,7 @@
                 "./src/tainted/string_resource.cc",
                 "./src/api/string_methods.cc",
                 "./src/api/concat.cc",
+                "./src/api/trim.cc",
                 "./src/iast.cc"
             ],
             "include_dirs" : [
@@ -32,7 +33,7 @@
                 ['OS=="win"', {
                     "win_delay_load_hook": 'false'
                 }]
-                
+
             ],
             'dependencies': [
                 "<!(node -p \"require('node-addon-api').gyp\")"

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,5 +25,7 @@ declare module 'datadog-iast-taint-tracking' {
         getRanges(transactionId: string, original: string): NativeTaintedRange[];
         removeTransaction(transactionId: string): void;
         concat(transactionId: string, result: string, op1: string, op2: string): string;
+        trim(transactionId: string, result: string, thisArg: string): string;
+        trimEnd(transactionId: string, result: string, thisArg: string): string;
     }
 }

--- a/index.js
+++ b/index.js
@@ -27,6 +27,12 @@ try {
     },
     concat (transactionId, result) {
       return result
+    },
+    trim (transaction, result) {
+      return result
+    },
+    trimEnd (transaction, result) {
+      return result
     }
   }
 }
@@ -37,7 +43,9 @@ const iastNativeMethods = {
   getRanges: addon.getRanges,
   createTransaction: addon.createTransaction,
   removeTransaction: addon.removeTransaction,
-  concat: addon.concat
+  concat: addon.concat,
+  trim: addon.trim,
+  trimEnd: addon.trimEnd
 }
 
 module.exports = iastNativeMethods

--- a/src/api/trim.cc
+++ b/src/api/trim.cc
@@ -5,6 +5,7 @@
 #include <new>
 #include <vector>
 #include <memory>
+#include <string>
 
 #include "trim.h"
 #include "../tainted/range.h"

--- a/src/api/trim.cc
+++ b/src/api/trim.cc
@@ -92,7 +92,7 @@ void TaintTrimOperator(const FunctionCallbackInfo<Value>& args) {
             }
         }
 
-        if (resultRanges != nullptr) {
+        if (resultRanges->Size() > 0) {
             auto key = utils::GetLocalStringPointer(args[1]);
             transaction->AddTainted(key, resultRanges, args[1]);
             args.GetReturnValue().Set(args[1]);
@@ -155,7 +155,7 @@ void TaintTrimEndOperator(const FunctionCallbackInfo<Value>& args) {
             }
         }
 
-        if (resultRanges != nullptr) {
+        if (resultRanges->Size() > 0) {
             auto key = utils::GetLocalStringPointer(args[1]);
             transaction->AddTainted(key, resultRanges, args[1]);
             args.GetReturnValue().Set(args[1]);

--- a/src/api/trim.cc
+++ b/src/api/trim.cc
@@ -47,11 +47,6 @@ void TaintTrimOperator(const FunctionCallbackInfo<Value>& args) {
 
     try {
         auto taintedObj = transaction->FindTaintedObject(utils::GetLocalStringPointer(args[2]));
-        if (taintedObj == nullptr) {
-            args.GetReturnValue().Set(args[1]);
-            return;
-        }
-
         auto ranges = taintedObj ? taintedObj->getRanges() : nullptr;
         if (ranges == nullptr) {
             args.GetReturnValue().Set(args[1]);
@@ -133,11 +128,6 @@ void TaintTrimEndOperator(const FunctionCallbackInfo<Value>& args) {
 
     try {
         auto taintedObj = transaction->FindTaintedObject(utils::GetLocalStringPointer(args[2]));
-        if (taintedObj == nullptr) {
-            args.GetReturnValue().Set(args[1]);
-            return;
-        }
-
         auto ranges = taintedObj ? taintedObj->getRanges() : nullptr;
         if (ranges == nullptr) {
             args.GetReturnValue().Set(args[1]);

--- a/src/api/trim.cc
+++ b/src/api/trim.cc
@@ -1,0 +1,186 @@
+/**
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+* This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+**/
+#include <new>
+#include <vector>
+#include <memory>
+
+#include "trim.h"
+#include "../tainted/range.h"
+#include "../tainted/transaction.h"
+#include "../iast.h"
+
+using v8::FunctionCallbackInfo;
+using v8::Value;
+using v8::Local;
+using v8::Isolate;
+using v8::Object;
+using v8::String;
+
+using iast::tainted::Range;
+
+namespace iast {
+namespace api {
+
+void TaintTrimOperator(const FunctionCallbackInfo<Value>& args) {
+    auto isolate = args.GetIsolate();
+
+    if (args.Length() < 3) {
+        isolate->ThrowException(v8::Exception::TypeError(
+                        v8::String::NewFromUtf8(isolate,
+                        "Wrong number of arguments",
+                        v8::NewStringType::kNormal).ToLocalChecked()));
+        return;
+    }
+    if (!args[1]->IsString()) {
+        args.GetReturnValue().Set(args[1]);
+        return;
+    }
+
+    auto transaction = GetTransaction(utils::GetLocalStringPointer(args[0]));
+    if (transaction == nullptr) {
+        args.GetReturnValue().Set(args[1]);
+        return;
+    }
+
+    try {
+        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalStringPointer(args[2]));
+        if (taintedObj == nullptr) {
+            args.GetReturnValue().Set(args[1]);
+            return;
+        }
+
+        auto ranges = taintedObj ? taintedObj->getRanges() : nullptr;
+        if (ranges == nullptr) {
+            args.GetReturnValue().Set(args[1]);
+            return;
+        }
+
+        v8::String::Utf8Value selfStr(isolate, args[2]);
+        std::string cSelf(*selfStr);
+        int selfLength = cSelf.length();
+
+        int left = 0;
+        while (left < selfLength) {
+            auto c = cSelf.at(left);
+            if (isspace(c)) {
+                left++;
+            } else {
+                break;
+            }
+        }
+
+        v8::String::Utf8Value resultStr(isolate, args[1]);
+        std::string cResultStr(*resultStr);
+        int resultLength = cResultStr.length();
+
+        auto resultRanges = transaction->GetSharedVectorRange();
+        auto end = ranges->end();
+        for (auto it = ranges->begin(); it != end; it++) {
+            auto range = *it;
+            int newRangeEnd = range->end - left;
+            int newRangeStart = range->start - left;
+
+            if (newRangeStart < 0) {
+                newRangeStart = 0;
+            }
+
+            if (newRangeEnd >= 0 && newRangeEnd > resultLength) {
+                newRangeEnd = resultLength;
+            }
+
+            if (newRangeEnd > newRangeStart) {
+                auto newRange = transaction->GetRange(newRangeStart, newRangeEnd, range->inputInfo);
+                resultRanges->PushBack(newRange);
+            }
+        }
+
+        if (resultRanges != nullptr) {
+            auto key = utils::GetLocalStringPointer(args[1]);
+            transaction->AddTainted(key, resultRanges, args[1]);
+            args.GetReturnValue().Set(args[1]);
+            return;
+        }
+    } catch (const std::bad_alloc& err) {
+    } catch (const container::QueuedPoolBadAlloc& err) {
+    } catch (const container::PoolBadAlloc& err) {
+    }
+    args.GetReturnValue().Set(args[1]);
+}
+
+void TaintTrimEndOperator(const FunctionCallbackInfo<Value>& args) {
+    auto isolate = args.GetIsolate();
+
+    if (args.Length() < 3) {
+        isolate->ThrowException(v8::Exception::TypeError(
+                        v8::String::NewFromUtf8(isolate,
+                        "Wrong number of arguments",
+                        v8::NewStringType::kNormal).ToLocalChecked()));
+        return;
+    }
+    if (!args[1]->IsString()) {
+        args.GetReturnValue().Set(args[1]);
+        return;
+    }
+
+    auto transaction = GetTransaction(utils::GetLocalStringPointer(args[0]));
+    if (transaction == nullptr) {
+        args.GetReturnValue().Set(args[1]);
+        return;
+    }
+
+    try {
+        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalStringPointer(args[2]));
+        if (taintedObj == nullptr) {
+            args.GetReturnValue().Set(args[1]);
+            return;
+        }
+
+        auto ranges = taintedObj ? taintedObj->getRanges() : nullptr;
+        if (ranges == nullptr) {
+            args.GetReturnValue().Set(args[1]);
+            return;
+        }
+
+        v8::String::Utf8Value resultStr(isolate, args[1]);
+        std::string cResultStr(*resultStr);
+        int resultLength = cResultStr.length();
+
+        auto resultRanges = transaction->GetSharedVectorRange();
+        auto end = ranges->end();
+        for (auto it = ranges->begin(); it != end; it++) {
+            auto range = *it;
+            int newRangeEnd = range->end;
+            int newRangeStart = range->start;
+
+            if (newRangeEnd > resultLength) {
+                newRangeEnd = resultLength;
+            }
+
+            if (newRangeEnd > newRangeStart) {
+                auto newRange = transaction->GetRange(newRangeStart, newRangeEnd, range->inputInfo);
+                resultRanges->PushBack(newRange);
+            }
+        }
+
+        if (resultRanges != nullptr) {
+            auto key = utils::GetLocalStringPointer(args[1]);
+            transaction->AddTainted(key, resultRanges, args[1]);
+            args.GetReturnValue().Set(args[1]);
+            return;
+        }
+    } catch (const std::bad_alloc& err) {
+    } catch (const container::QueuedPoolBadAlloc& err) {
+    } catch (const container::PoolBadAlloc& err) {
+    }
+    args.GetReturnValue().Set(args[1]);
+}
+
+void TrimOperations::Init(Local<Object> exports) {
+    NODE_SET_METHOD(exports, "trim", TaintTrimOperator);
+    NODE_SET_METHOD(exports, "trimEnd", TaintTrimEndOperator);
+}
+}   // namespace api
+}   // namespace iast
+

--- a/src/api/trim.cc
+++ b/src/api/trim.cc
@@ -53,19 +53,16 @@ void TaintTrimOperator(const FunctionCallbackInfo<Value>& args) {
             return;
         }
 
-        v8::String::Utf8Value selfStr(isolate, args[2]);
-        std::string cSelf(*selfStr);
-        int selfLength = cSelf.length();
-
         int left = 0;
-        while (left < selfLength) {
-            auto c = cSelf.at(left);
-            if (isspace(c)) {
-                left++;
-            } else {
+        v8::String::Utf8Value selfStr(isolate, args[2]);
+
+        char * selfCh = *selfStr;
+        do {
+            if (!isspace(*selfCh)) {
                 break;
             }
-        }
+            left++;
+        } while (*selfCh++);
 
         v8::String::Utf8Value resultStr(isolate, args[1]);
         std::string cResultStr(*resultStr);

--- a/src/api/trim.h
+++ b/src/api/trim.h
@@ -1,0 +1,21 @@
+/**
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+* This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+**/
+#ifndef SRC_API_TRIM_H_
+#define SRC_API_TRIM_H_
+
+#include <node.h>
+namespace iast {
+namespace api {
+class TrimOperations {
+ public:
+    static void Init(v8::Local<v8::Object> exports);
+
+ private:
+    TrimOperations();
+    ~TrimOperations();
+};
+}   // namespace api
+}   // namespace iast
+#endif  // SRC_API_TRIM_H_

--- a/src/iast.cc
+++ b/src/iast.cc
@@ -11,6 +11,7 @@
 #include "api/string_methods.h"
 #include "tainted/transaction.h"
 #include "api/concat.h"
+#include "api/trim.h"
 
 using transactionManger = iast::container::Singleton<iast::TransactionManager<iast::tainted::Transaction,
       iast::tainted::transaction_key_t>>;
@@ -36,6 +37,7 @@ Transaction* NewTransaction(transaction_key_t id) {
 void Init(v8::Local<v8::Object> exports) {
     api::StringMethods::Init(exports);
     api::ConcatOperations::Init(exports);
+    api::TrimOperations::Init(exports);
     exports->GetIsolate()->AddGCEpilogueCallback(iast::gc::OnScavenge, v8::GCType::kGCTypeScavenge);
     exports->GetIsolate()->AddGCEpilogueCallback(iast::gc::OnMarkSweepCompact, v8::GCType::kGCTypeMarkSweepCompact);
 }

--- a/test/js/trim.spec.js
+++ b/test/js/trim.spec.js
@@ -256,9 +256,15 @@ describe('Trim operator', function () {
     TaintedUtils.removeTransaction(id)
   })
 
-  it('Wrong arguments', function () {
+  it('Wrong arguments trim', function () {
     assert.throws(function () {
-      TaintedUtils.concat(id)
+      TaintedUtils.trim(id)
+    }, Error)
+  })
+
+  it('Wrong arguments trimEnd', function () {
+    assert.throws(function () {
+      TaintedUtils.trimEnd(id)
     }, Error)
   })
 

--- a/test/js/trim.spec.js
+++ b/test/js/trim.spec.js
@@ -259,7 +259,7 @@ describe('Trim operator', function () {
   }
 
   function testTrimNoTaintedResult (trimFn, taintedTrimFn) {
-    let testString = '   ABC   '
+    const testString = '   ABC   '
     const res = trimFn.call(testString)
     const ret = taintedTrimFn(id, res, testString)
     assert.equal(res, ret, 'Unexpected vale')
@@ -278,7 +278,7 @@ describe('Trim operator', function () {
     assert.equal(formattedResult, expectedResult, 'Unexpected ranges')
   }
 
-  function testTrimNoTaintedWhenAllRangesTrimmed(trimFn, taintedTrimFn, formattedTestString) {
+  function testTrimNoTaintedWhenAllRangesTrimmed (trimFn, taintedTrimFn, formattedTestString) {
     const testString = taintFormattedString(id, formattedTestString)
     const res = trimFn.call(testString)
     assert.equal(TaintedUtils.isTainted(id, testString), true, 'Test string not tainted')

--- a/test/js/trim.spec.js
+++ b/test/js/trim.spec.js
@@ -10,16 +10,22 @@ describe('Trim operator', function () {
 
   const noTaintTestCases = {
     trim: [
+      ':+-    -+:',
+      ':+- \n\r\t -+:',
       ':+-    -+:ABC:+-    -+:',
       ' :+-    -+:ABC:+-    -+: ',
       ' :+-    -+: ABC :+-    -+: '
     ],
     trimStart: [
+      ':+-    -+:',
+      ':+- \n\r\t -+:',
       ':+-    -+:ABC',
       ' :+-    -+: ABC ',
       ' :+-    -+: :+-    -+: ABC'
     ],
     trimEnd: [
+      ':+-    -+:',
+      ':+- \n\r\t -+:',
       'ABC:+-    -+:',
       'ABC :+-    -+: ',
       'ABC :+-    -+: :+-    -+: '

--- a/test/js/trim.spec.js
+++ b/test/js/trim.spec.js
@@ -2,7 +2,7 @@
  * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
  * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
  **/
-const { TaintedUtils, taintFormattedString, formatTaintedValue} = require('./util')
+const { TaintedUtils, taintFormattedString, formatTaintedValue } = require('./util')
 const assert = require('assert')
 
 describe('Trim operator', function () {
@@ -224,10 +224,10 @@ describe('Trim operator', function () {
       trimResult: ':+-佫-+: :+-😂😂😂-+: :+-𝒳-+:',
       trimStartResult: ':+-佫-+: :+-😂😂😂-+: :+-𝒳  -+: ',
       trimEndResult: ' :+-  佫-+: :+-😂😂😂-+: :+-𝒳-+:'
-    },
+    }
   ]
 
-  function testTrimResult(trimFn, taintedTrimFn) {
+  function testTrimResult (trimFn, taintedTrimFn) {
     let testString = '   ABC   '
 
     testString = TaintedUtils.newTaintedString(id, testString, 'PARAM_NAME', 'PARAM_TYPE')
@@ -240,7 +240,7 @@ describe('Trim operator', function () {
     assert.equal(true, TaintedUtils.isTainted(id, ret), 'Unexpected value')
   }
 
-  function testTrimCheckRanges(trimFn, taintedTrimFn, formattedTestString, expectedResult) {
+  function testTrimCheckRanges (trimFn, taintedTrimFn, formattedTestString, expectedResult) {
     const testString = taintFormattedString(id, formattedTestString)
     const res = trimFn.call(testString)
     assert.equal(TaintedUtils.isTainted(id, testString), true, 'Test string not tainted')
@@ -262,14 +262,13 @@ describe('Trim operator', function () {
     }, Error)
   })
 
-
   describe('trim', function () {
     it('Check result', function () {
       testTrimResult(String.prototype.trim, TaintedUtils.trim)
     })
 
     describe('Check ranges', function () {
-      testCases.forEach(({testString, trimResult}) => {
+      testCases.forEach(({ testString, trimResult }) => {
         it(`Test ${testString}`, () => {
           testTrimCheckRanges(String.prototype.trim, TaintedUtils.trim, testString, trimResult)
         })
@@ -283,7 +282,7 @@ describe('Trim operator', function () {
     })
 
     describe('Check ranges', function () {
-      testCases.forEach(({testString, trimStartResult}) => {
+      testCases.forEach(({ testString, trimStartResult }) => {
         it(`Test ${testString}`, () => {
           testTrimCheckRanges(String.prototype.trimStart, TaintedUtils.trim, testString, trimStartResult)
         })
@@ -297,13 +296,11 @@ describe('Trim operator', function () {
     })
 
     describe('Check ranges', function () {
-      testCases.forEach(({testString, trimEndResult}) => {
+      testCases.forEach(({ testString, trimEndResult }) => {
         it(`Test ${testString}`, () => {
           testTrimCheckRanges(String.prototype.trimEnd, TaintedUtils.trimEnd, testString, trimEndResult)
         })
       })
     })
   })
-
-
 })

--- a/test/js/trim.spec.js
+++ b/test/js/trim.spec.js
@@ -256,19 +256,13 @@ describe('Trim operator', function () {
     TaintedUtils.removeTransaction(id)
   })
 
-  it('Wrong arguments trim', function () {
-    assert.throws(function () {
-      TaintedUtils.trim(id)
-    }, Error)
-  })
-
-  it('Wrong arguments trimEnd', function () {
-    assert.throws(function () {
-      TaintedUtils.trimEnd(id)
-    }, Error)
-  })
-
   describe('trim', function () {
+    it('Wrong arguments trim', function () {
+      assert.throws(function () {
+        TaintedUtils.trim(id)
+      }, Error)
+    })
+
     it('Check result', function () {
       testTrimResult(String.prototype.trim, TaintedUtils.trim)
     })
@@ -297,6 +291,12 @@ describe('Trim operator', function () {
   })
 
   describe('trimEnd', function () {
+    it('Wrong arguments trimEnd', function () {
+      assert.throws(function () {
+        TaintedUtils.trimEnd(id)
+      }, Error)
+    })
+
     it('Check result', function () {
       testTrimResult(String.prototype.trimEnd, TaintedUtils.trimEnd)
     })

--- a/test/js/trim.spec.js
+++ b/test/js/trim.spec.js
@@ -258,6 +258,14 @@ describe('Trim operator', function () {
     assert.equal(true, TaintedUtils.isTainted(id, ret), 'Unexpected value')
   }
 
+  function testTrimNoTaintedResult (trimFn, taintedTrimFn) {
+    let testString = '   ABC   '
+    const res = trimFn.call(testString)
+    const ret = taintedTrimFn(id, res, testString)
+    assert.equal(res, ret, 'Unexpected vale')
+    assert.equal(false, TaintedUtils.isTainted(id, ret), 'Unexpected value')
+  }
+
   function testTrimCheckRanges (trimFn, taintedTrimFn, formattedTestString, expectedResult) {
     const testString = taintFormattedString(id, formattedTestString)
     const res = trimFn.call(testString)
@@ -294,6 +302,10 @@ describe('Trim operator', function () {
       testTrimResult(String.prototype.trim, TaintedUtils.trim)
     })
 
+    it('Check result from not tainted value', function () {
+      testTrimNoTaintedResult(String.prototype.trim, TaintedUtils.trim)
+    })
+
     describe('Check result not tainted when no ranges left', function () {
       noTaintTestCases.trim.forEach((testString) => {
         it(`Test ${testString}`, () => {
@@ -314,6 +326,10 @@ describe('Trim operator', function () {
   describe('trimStart', function () {
     it('Check result', function () {
       testTrimResult(String.prototype.trimStart, TaintedUtils.trim)
+    })
+
+    it('Check result from not tainted value', function () {
+      testTrimNoTaintedResult(String.prototype.trimStart, TaintedUtils.trim)
     })
 
     describe('Check result not tainted when no ranges left', function () {
@@ -342,6 +358,10 @@ describe('Trim operator', function () {
 
     it('Check result', function () {
       testTrimResult(String.prototype.trimEnd, TaintedUtils.trimEnd)
+    })
+
+    it('Check result from not tainted value', function () {
+      testTrimNoTaintedResult(String.prototype.trimEnd, TaintedUtils.trimEnd)
     })
 
     describe('Check result not tainted when no ranges left', function () {

--- a/test/js/trim.spec.js
+++ b/test/js/trim.spec.js
@@ -1,0 +1,309 @@
+/**
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+ **/
+const { TaintedUtils, taintFormattedString, formatTaintedValue} = require('./util')
+const assert = require('assert')
+
+describe('Trim operator', function () {
+  const id = '1'
+
+  const testCases = [
+    {
+      testString: ':+-ABC-+:',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+:',
+      trimEndResult: ':+-ABC-+:'
+    },
+    {
+      testString: ':+-ABC-+:   ',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+:   ',
+      trimEndResult: ':+-ABC-+:'
+    },
+    {
+      testString: '   :+-ABC-+:',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+:',
+      trimEndResult: '   :+-ABC-+:'
+    },
+    {
+      testString: '   :+-ABC-+:   ',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+:   ',
+      trimEndResult: '   :+-ABC-+:'
+    },
+    {
+      testString: '   \n   :+-ABC-+:   \n   ',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+:   \n   ',
+      trimEndResult: '   \n   :+-ABC-+:'
+    },
+    {
+      testString: '   \t   :+-ABC-+:   \t   ',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+:   \t   ',
+      trimEndResult: '   \t   :+-ABC-+:'
+    },
+    {
+      testString: '   \r   :+-ABC-+:   \r   ',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+:   \r   ',
+      trimEndResult: '   \r   :+-ABC-+:'
+    },
+    {
+      testString: ':+-   -+::+-ABC-+:',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+:',
+      trimEndResult: ':+-   -+::+-ABC-+:'
+    },
+    {
+      testString: ':+-  12-+::+-ABC-+:',
+      trimResult: ':+-12-+::+-ABC-+:',
+      trimStartResult: ':+-12-+::+-ABC-+:',
+      trimEndResult: ':+-  12-+::+-ABC-+:'
+    },
+    {
+      testString: ' :+-  12-+::+-ABC-+:',
+      trimResult: ':+-12-+::+-ABC-+:',
+      trimStartResult: ':+-12-+::+-ABC-+:',
+      trimEndResult: ' :+-  12-+::+-ABC-+:'
+    },
+    {
+      testString: ':+-   -+: :+-ABC-+:',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+:',
+      trimEndResult: ':+-   -+: :+-ABC-+:'
+    },
+    {
+      testString: ':+-   -+: :+-ABC-+: ',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+: ',
+      trimEndResult: ':+-   -+: :+-ABC-+:'
+    },
+    {
+      testString: ':+-ABC-+::+-   -+:',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+::+-   -+:',
+      trimEndResult: ':+-ABC-+:'
+    },
+    {
+      testString: ':+-ABC-+::+-12  -+:',
+      trimResult: ':+-ABC-+::+-12-+:',
+      trimStartResult: ':+-ABC-+::+-12  -+:',
+      trimEndResult: ':+-ABC-+::+-12-+:'
+    },
+    {
+      testString: ':+-ABC-+::+-12  -+: ',
+      trimResult: ':+-ABC-+::+-12-+:',
+      trimStartResult: ':+-ABC-+::+-12  -+: ',
+      trimEndResult: ':+-ABC-+::+-12-+:'
+    },
+    {
+      testString: ':+-ABC-+: :+-   -+:',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+: :+-   -+:',
+      trimEndResult: ':+-ABC-+:'
+    },
+    {
+      testString: ' :+-ABC-+: :+-   -+:',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+: :+-   -+:',
+      trimEndResult: ' :+-ABC-+:'
+    },
+    {
+      testString: ':+-ABC-+:12345:+-   -+:',
+      trimResult: ':+-ABC-+:12345',
+      trimStartResult: ':+-ABC-+:12345:+-   -+:',
+      trimEndResult: ':+-ABC-+:12345'
+    },
+    {
+      testString: ':+-ABC-+:12345   :+-   -+: ',
+      trimResult: ':+-ABC-+:12345',
+      trimStartResult: ':+-ABC-+:12345   :+-   -+: ',
+      trimEndResult: ':+-ABC-+:12345'
+    },
+    {
+      testString: ':+-ABC-+::+-   -+:12345    ',
+      trimResult: ':+-ABC-+::+-   -+:12345',
+      trimStartResult: ':+-ABC-+::+-   -+:12345    ',
+      trimEndResult: ':+-ABC-+::+-   -+:12345'
+    },
+    {
+      testString: ':+-   -+:12345:+-ABC-+:',
+      trimResult: '12345:+-ABC-+:',
+      trimStartResult: '12345:+-ABC-+:',
+      trimEndResult: ':+-   -+:12345:+-ABC-+:'
+    },
+    {
+      testString: ' :+-   -+:   12345:+-ABC-+:',
+      trimResult: '12345:+-ABC-+:',
+      trimStartResult: '12345:+-ABC-+:',
+      trimEndResult: ' :+-   -+:   12345:+-ABC-+:'
+    },
+    {
+      testString: '   12345:+-   -+::+-ABC-+:',
+      trimResult: '12345:+-   -+::+-ABC-+:',
+      trimStartResult: '12345:+-   -+::+-ABC-+:',
+      trimEndResult: '   12345:+-   -+::+-ABC-+:'
+    },
+    {
+      testString: '   12345:+-   -+::+-ABC-+::+-   -+:67890   ',
+      trimResult: '12345:+-   -+::+-ABC-+::+-   -+:67890',
+      trimStartResult: '12345:+-   -+::+-ABC-+::+-   -+:67890   ',
+      trimEndResult: '   12345:+-   -+::+-ABC-+::+-   -+:67890'
+    },
+    {
+      testString: '   \n   12345:+-   -+::+-ABC-+::+-   -+:67890   \n   ',
+      trimResult: '12345:+-   -+::+-ABC-+::+-   -+:67890',
+      trimStartResult: '12345:+-   -+::+-ABC-+::+-   -+:67890   \n   ',
+      trimEndResult: '   \n   12345:+-   -+::+-ABC-+::+-   -+:67890'
+    },
+    {
+      testString: '   \t   12345:+-   -+::+-ABC-+::+-   -+:67890   \t   ',
+      trimResult: '12345:+-   -+::+-ABC-+::+-   -+:67890',
+      trimStartResult: '12345:+-   -+::+-ABC-+::+-   -+:67890   \t   ',
+      trimEndResult: '   \t   12345:+-   -+::+-ABC-+::+-   -+:67890'
+    },
+    {
+      testString: '   \r   12345:+-   -+::+-ABC-+::+-   -+:67890   \r   ',
+      trimResult: '12345:+-   -+::+-ABC-+::+-   -+:67890',
+      trimStartResult: '12345:+-   -+::+-ABC-+::+-   -+:67890   \r   ',
+      trimEndResult: '   \r   12345:+-   -+::+-ABC-+::+-   -+:67890'
+    },
+    {
+      testString: ':+-12345-+::+-ABC-+::+-67890-+:',
+      trimResult: ':+-12345-+::+-ABC-+::+-67890-+:',
+      trimStartResult: ':+-12345-+::+-ABC-+::+-67890-+:',
+      trimEndResult: ':+-12345-+::+-ABC-+::+-67890-+:'
+    },
+    {
+      testString: ' :+-  12345-+: :+-ABC-+: :+-67890  -+: ',
+      trimResult: ':+-12345-+: :+-ABC-+: :+-67890-+:',
+      trimStartResult: ':+-12345-+: :+-ABC-+: :+-67890  -+: ',
+      trimEndResult: ' :+-  12345-+: :+-ABC-+: :+-67890-+:'
+    },
+    {
+      testString: ':+-   -+: :+-   -+: :+-ABC-+: ',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+: ',
+      trimEndResult: ':+-   -+: :+-   -+: :+-ABC-+:'
+    },
+    {
+      testString: ' :+-   -+: :+-   -+: :+-ABC-+: ',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+: ',
+      trimEndResult: ' :+-   -+: :+-   -+: :+-ABC-+:'
+    },
+    {
+      testString: ' :+-   -+: :+-   -+: :+-ABC-+: :+-   -+: ',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+: :+-   -+: ',
+      trimEndResult: ' :+-   -+: :+-   -+: :+-ABC-+:'
+    },
+    {
+      testString: ' :+-   -+: :+-   -+: :+-ABC-+: :+-   -+: :+-   -+: ',
+      trimResult: ':+-ABC-+:',
+      trimStartResult: ':+-ABC-+: :+-   -+: :+-   -+: ',
+      trimEndResult: ' :+-   -+: :+-   -+: :+-ABC-+:'
+    },
+    {
+      testString: ' :+-   -+: :+-   -+: :+-  ABC-+: :+-1234567890  -+: :+-   -+: :+-   -+: ',
+      trimResult: ':+-ABC-+: :+-1234567890-+:',
+      trimStartResult: ':+-ABC-+: :+-1234567890  -+: :+-   -+: :+-   -+: ',
+      trimEndResult: ' :+-   -+: :+-   -+: :+-  ABC-+: :+-1234567890-+:'
+    },
+    {
+      testString: '   佫:+-   -+::+-😂😂😂-+::+-   -+:𝒳   ',
+      trimResult: '佫:+-   -+::+-😂😂😂-+::+-   -+:𝒳',
+      trimStartResult: '佫:+-   -+::+-😂😂😂-+::+-   -+:𝒳   ',
+      trimEndResult: '   佫:+-   -+::+-😂😂😂-+::+-   -+:𝒳'
+    },
+    {
+      testString: ' :+-  佫-+: :+-😂😂😂-+: :+-𝒳  -+: ',
+      trimResult: ':+-佫-+: :+-😂😂😂-+: :+-𝒳-+:',
+      trimStartResult: ':+-佫-+: :+-😂😂😂-+: :+-𝒳  -+: ',
+      trimEndResult: ' :+-  佫-+: :+-😂😂😂-+: :+-𝒳-+:'
+    },
+  ]
+
+  function testTrimResult(trimFn, taintedTrimFn) {
+    let testString = '   ABC   '
+
+    testString = TaintedUtils.newTaintedString(id, testString, 'PARAM_NAME', 'PARAM_TYPE')
+    assert.strictEqual(testString, '   ABC   ', 'Unexpected value')
+    assert.equal(true, TaintedUtils.isTainted(id, testString), 'Unexpected value')
+
+    const res = trimFn.call(testString)
+    const ret = taintedTrimFn(id, res, testString)
+    assert.equal(res, ret, 'Unexpected vale')
+    assert.equal(true, TaintedUtils.isTainted(id, ret), 'Unexpected value')
+  }
+
+  function testTrimCheckRanges(trimFn, taintedTrimFn, formattedTestString, expectedResult) {
+    const testString = taintFormattedString(id, formattedTestString)
+    const res = trimFn.call(testString)
+    assert.equal(TaintedUtils.isTainted(id, testString), true, 'Test string not tainted')
+    const ret = taintedTrimFn(id, res, testString)
+    assert.equal(res, ret, 'Unexpected vale')
+    assert.equal(TaintedUtils.isTainted(id, ret), true, 'Trim returned value not tainted')
+
+    const formattedResult = formatTaintedValue(id, ret)
+    assert.equal(formattedResult, expectedResult, 'Unexpected ranges')
+  }
+
+  afterEach(function () {
+    TaintedUtils.removeTransaction(id)
+  })
+
+  it('Wrong arguments', function () {
+    assert.throws(function () {
+      TaintedUtils.concat(id)
+    }, Error)
+  })
+
+
+  describe('trim', function () {
+    it('Check result', function () {
+      testTrimResult(String.prototype.trim, TaintedUtils.trim)
+    })
+
+    describe('Check ranges', function () {
+      testCases.forEach(({testString, trimResult}) => {
+        it(`Test ${testString}`, () => {
+          testTrimCheckRanges(String.prototype.trim, TaintedUtils.trim, testString, trimResult)
+        })
+      })
+    })
+  })
+
+  describe('trimStart', function () {
+    it('Check result', function () {
+      testTrimResult(String.prototype.trimStart, TaintedUtils.trim)
+    })
+
+    describe('Check ranges', function () {
+      testCases.forEach(({testString, trimStartResult}) => {
+        it(`Test ${testString}`, () => {
+          testTrimCheckRanges(String.prototype.trimStart, TaintedUtils.trim, testString, trimStartResult)
+        })
+      })
+    })
+  })
+
+  describe('trimEnd', function () {
+    it('Check result', function () {
+      testTrimResult(String.prototype.trimEnd, TaintedUtils.trimEnd)
+    })
+
+    describe('Check ranges', function () {
+      testCases.forEach(({testString, trimEndResult}) => {
+        it(`Test ${testString}`, () => {
+          testTrimCheckRanges(String.prototype.trimEnd, TaintedUtils.trimEnd, testString, trimEndResult)
+        })
+      })
+    })
+  })
+
+
+})

--- a/test/js/trim.spec.js
+++ b/test/js/trim.spec.js
@@ -8,7 +8,25 @@ const assert = require('assert')
 describe('Trim operator', function () {
   const id = '1'
 
-  const testCases = [
+  const noTaintTestCases = {
+    trim: [
+      ':+-    -+:ABC:+-    -+:',
+      ' :+-    -+:ABC:+-    -+: ',
+      ' :+-    -+: ABC :+-    -+: '
+    ],
+    trimStart: [
+      ':+-    -+:ABC',
+      ' :+-    -+: ABC ',
+      ' :+-    -+: :+-    -+: ABC'
+    ],
+    trimEnd: [
+      'ABC:+-    -+:',
+      'ABC :+-    -+: ',
+      'ABC :+-    -+: :+-    -+: '
+    ]
+  }
+
+  const rangesTestCases = [
     {
       testString: ':+-ABC-+:',
       trimResult: ':+-ABC-+:',
@@ -252,6 +270,15 @@ describe('Trim operator', function () {
     assert.equal(formattedResult, expectedResult, 'Unexpected ranges')
   }
 
+  function testTrimNoTaintedWhenAllRangesTrimmed(trimFn, taintedTrimFn, formattedTestString) {
+    const testString = taintFormattedString(id, formattedTestString)
+    const res = trimFn.call(testString)
+    assert.equal(TaintedUtils.isTainted(id, testString), true, 'Test string not tainted')
+    const ret = taintedTrimFn(id, res, testString)
+    assert.equal(res, ret, 'Unexpected vale')
+    assert.equal(TaintedUtils.isTainted(id, ret), false, 'Trim returned value is tainted')
+  }
+
   afterEach(function () {
     TaintedUtils.removeTransaction(id)
   })
@@ -267,8 +294,16 @@ describe('Trim operator', function () {
       testTrimResult(String.prototype.trim, TaintedUtils.trim)
     })
 
+    describe('Check result not tainted when no ranges left', function () {
+      noTaintTestCases.trim.forEach((testString) => {
+        it(`Test ${testString}`, () => {
+          testTrimNoTaintedWhenAllRangesTrimmed(String.prototype.trim, TaintedUtils.trim, testString)
+        })
+      })
+    })
+
     describe('Check ranges', function () {
-      testCases.forEach(({ testString, trimResult }) => {
+      rangesTestCases.forEach(({ testString, trimResult }) => {
         it(`Test ${testString}`, () => {
           testTrimCheckRanges(String.prototype.trim, TaintedUtils.trim, testString, trimResult)
         })
@@ -281,8 +316,16 @@ describe('Trim operator', function () {
       testTrimResult(String.prototype.trimStart, TaintedUtils.trim)
     })
 
+    describe('Check result not tainted when no ranges left', function () {
+      noTaintTestCases.trimStart.forEach((testString) => {
+        it(`Test ${testString}`, () => {
+          testTrimNoTaintedWhenAllRangesTrimmed(String.prototype.trimStart, TaintedUtils.trim, testString)
+        })
+      })
+    })
+
     describe('Check ranges', function () {
-      testCases.forEach(({ testString, trimStartResult }) => {
+      rangesTestCases.forEach(({ testString, trimStartResult }) => {
         it(`Test ${testString}`, () => {
           testTrimCheckRanges(String.prototype.trimStart, TaintedUtils.trim, testString, trimStartResult)
         })
@@ -301,8 +344,16 @@ describe('Trim operator', function () {
       testTrimResult(String.prototype.trimEnd, TaintedUtils.trimEnd)
     })
 
+    describe('Check result not tainted when no ranges left', function () {
+      noTaintTestCases.trimEnd.forEach((testString) => {
+        it(`Test ${testString}`, () => {
+          testTrimNoTaintedWhenAllRangesTrimmed(String.prototype.trimEnd, TaintedUtils.trimEnd, testString)
+        })
+      })
+    })
+
     describe('Check ranges', function () {
-      testCases.forEach(({ testString, trimEndResult }) => {
+      rangesTestCases.forEach(({ testString, trimEndResult }) => {
         it(`Test ${testString}`, () => {
           testTrimCheckRanges(String.prototype.trimEnd, TaintedUtils.trimEnd, testString, trimEndResult)
         })

--- a/test/js/util.js
+++ b/test/js/util.js
@@ -5,4 +5,48 @@
 const taintedUtilsPkg = process.env.NPM_TAINTEDUTILS === 'true' ? '@datadog/native-iast-taint-tracking' : '../../index'
 const TaintedUtils = require(taintedUtilsPkg)
 
-module.exports.TaintedUtils = TaintedUtils
+const RANGE_OPEN_MARK = ':+-'
+const RANGE_CLOSING_MARK = '-+:'
+
+const PARAM_NAME = 'param'
+const PARAM_TYPE = 'REQUEST'
+
+function taintFormattedString(transactionId, formattedString) {
+  return formattedString.split(RANGE_OPEN_MARK).reduce((previousValue, currentValue) => {
+    if (currentValue.length === 0) {
+      return previousValue
+    }
+    if (currentValue.indexOf(RANGE_CLOSING_MARK) > -1) {
+      const splitParts = currentValue.split(RANGE_CLOSING_MARK)
+      const tainted = TaintedUtils.newTaintedString(transactionId, splitParts[0], PARAM_NAME, PARAM_TYPE)
+      const previousPlusTainted = TaintedUtils.concat(transactionId, previousValue + tainted, previousValue, tainted)
+      if (splitParts.length === 1) return previousPlusTainted
+      const literal = splitParts[1]
+      return TaintedUtils.concat(transactionId, previousPlusTainted + literal, previousPlusTainted, literal)
+    } else {
+      return TaintedUtils.concat(transactionId, previousValue + currentValue, previousValue, currentValue)
+    }
+  }, '')
+}
+
+function formatTaintedValue(transactionId, taintedValue) {
+  let offset = 0
+  return TaintedUtils.getRanges(transactionId, taintedValue).reduce((formattedString, range) => {
+    formattedString =
+      formattedString.slice(0, range.start + offset) +
+      RANGE_OPEN_MARK +
+      formattedString.slice(range.start + offset)
+    offset += RANGE_OPEN_MARK.length
+    formattedString = formattedString.slice(0, range.end + offset) +
+      RANGE_CLOSING_MARK +
+      formattedString.slice(range.end + offset)
+    offset += RANGE_CLOSING_MARK.length
+    return formattedString
+  }, taintedValue)
+}
+
+module.exports = {
+  TaintedUtils,
+  taintFormattedString,
+  formatTaintedValue
+}

--- a/test/js/util.js
+++ b/test/js/util.js
@@ -11,7 +11,7 @@ const RANGE_CLOSING_MARK = '-+:'
 const PARAM_NAME = 'param'
 const PARAM_TYPE = 'REQUEST'
 
-function taintFormattedString(transactionId, formattedString) {
+function taintFormattedString (transactionId, formattedString) {
   return formattedString.split(RANGE_OPEN_MARK).reduce((previousValue, currentValue) => {
     if (currentValue.length === 0) {
       return previousValue
@@ -29,7 +29,7 @@ function taintFormattedString(transactionId, formattedString) {
   }, '')
 }
 
-function formatTaintedValue(transactionId, taintedValue) {
+function formatTaintedValue (transactionId, taintedValue) {
   let offset = 0
   return TaintedUtils.getRanges(transactionId, taintedValue).reduce((formattedString, range) => {
     formattedString =


### PR DESCRIPTION
### What does this PR do?

Add a native method to taint tracking the result of `trim`, `trimStart` and `trimEnd `string operations.

### Motivation

Propagate taint for string `trim` operations

### Additional Notes

The native `trim` method is used for both `trim` and `trimStart` since it works for both of them.

