### PR TITLE
Fix segfault when the transaction ID is either empty or undefined.

### DIFF
--- a/src/api/string_methods.cc
+++ b/src/api/string_methods.cc
@@ -50,15 +50,20 @@ void NewTaintedString(const FunctionCallbackInfo<Value>& args) {
         return;
     }
 
-    auto transactionIdArgument = args[0];
-    auto parameterValue = args[1];
-    auto parameterName = args[2];
-    auto type = args[3];
+    if (!(args[0]->IsString()) || !Local<String>::Cast(args[0])->Length()) {
+        args.GetReturnValue().Set(args[1]);
+        return;
+    }
 
     if (!(args[1]->IsString())) {
         args.GetReturnValue().Set(args[1]);
         return;
     }
+
+    auto transactionIdArgument = args[0];
+    auto parameterValue = args[1];
+    auto parameterName = args[2];
+    auto type = args[3];
 
     // if string length == 1 then make a new one in order to avoid chache issues.
     if (v8::Local<v8::String>::Cast(args[1])->Length() == 1) {

--- a/test/js/new_tainted_string.spec.js
+++ b/test/js/new_tainted_string.spec.js
@@ -7,10 +7,20 @@ const assert = require('assert')
 
 describe('Taint strings', function () {
   const value = 'test'
-  const id = '1'
+  const id = TaintedUtils.createTransaction('1')
 
   afterEach(function () {
     TaintedUtils.removeTransaction(id)
+  })
+
+  it('Taint new string with undefined transaction', function () {
+    const ret = TaintedUtils.newTaintedString(undefined, value, 'param', 'REQUEST')
+    assert.strictEqual(ret, 'test', 'Unexpected value')
+  })
+
+  it('Taint new string with empty transaction', function () {
+    const ret = TaintedUtils.newTaintedString('', value, 'param', 'REQUEST')
+    assert.strictEqual(ret, 'test', 'Unexpected value')
   })
 
   it('Taint new string', function () {


### PR DESCRIPTION
### What does this PR do?

Fix segmentation fault when an unexpected value come as a transaction identifier.


### Checklist

- [x] Unit tests have been updated and pass


