### PR TITLE
[CONTSEC-707] Upgrade CodeQL Github Action versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           config-file: .github/codeql_config.yml
@@ -52,7 +52,7 @@ jobs:
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
The CodeQL Action v1 is scheduled to be deprecated by January 2023. No new updates will be made to v1, which means that new CodeQL analysis capabilities will only be available to users of v2.

Hence upgrading the version of CodeQL github actions to v2.

More info here: https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/

Also upgrading actions/checkout version to v3 for: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected

