### PR TITLE
Check transaction is created on new tainted string

### DIFF
--- a/src/api/string_methods.cc
+++ b/src/api/string_methods.cc
@@ -82,6 +82,9 @@ void NewTaintedString(const FunctionCallbackInfo<Value>& args) {
 
     try {
         auto transaction = NewTransaction(transactionId);
+        if (transaction == nullptr) {
+            return;
+        }
         auto taintedObj = transaction->FindTaintedObject(utils::GetLocalStringPointer(parameterValue));
         if (taintedObj) {
             // Object already exist, nothing to do

--- a/test/js/new_tainted_string.spec.js
+++ b/test/js/new_tainted_string.spec.js
@@ -110,6 +110,17 @@ describe('Taint strings', function () {
     })
   })
 
+  it('Beyond max concurrent transactions', function () {
+    const MAX_TRANSACTION_MAP_SIZE = 2
+    const transactions = []
+    for (let i = 1; i < MAX_TRANSACTION_MAP_SIZE + 1; i++) {
+      transactions[i] = TaintedUtils.createTransaction(`beyondTest${i}`)
+      TaintedUtils.newTaintedString(transactions[i], `taintedString${i}`, 'param', 'request')
+    }
+
+    transactions.forEach((transactionId) => TaintedUtils.removeTransaction(transactionId))
+  })
+
   it('Beyond Max values', function () {
     let ret
     // let id = '1';


### PR DESCRIPTION
### What does this PR do?
The creation of a new transaction may return a null pointer if the size of the transaction map exceeds the maximum.
This PR adds a check to prevent SIGSEGV when creating a new tainted string.

### Motivation
Some SIGSEGV observed.

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected

