### PR TITLE
Fix verbosity level precedency.

### DIFF
--- a/src/api/metrics.cc
+++ b/src/api/metrics.cc
@@ -51,6 +51,7 @@ void GetMetrics(const FunctionCallbackInfo<Value>& args) {
     auto context = isolate->GetCurrentContext();
     auto jsMetrics = Object::New(isolate);
     switch (static_cast<TelemetryVerbosity>(telemetryVerbosity->IntegerValue(context).FromJust())) {
+        case TelemetryVerbosity::DEBUG:
         case TelemetryVerbosity::INFORMATION:
             jsMetrics->Set(context,
                     utils::NewV8String(isolate, "requestCount"),

--- a/src/api/string_methods.cc
+++ b/src/api/string_methods.cc
@@ -31,7 +31,6 @@ using v8::Object;
 using v8::String;
 using v8::Value;
 using v8::Array;
-using v8::Number;
 
 using iast::tainted::InputInfo;
 

--- a/test/js/metrics.spec.js
+++ b/test/js/metrics.spec.js
@@ -46,4 +46,14 @@ describe('Metrics', function () {
     expected.requestCount = 2
     assert.deepEqual(expected, TaintedUtils.getMetrics(id, Verbosity.INFORMATION), 'Metrics expected to be equal')
   })
+
+  it('Should return the properties in all verbosity levels', function () {
+    const expected = {
+      requestCount: 1
+    }
+
+    TaintedUtils.newTaintedString(id, 'a', 'param', 'request')
+    assert.deepEqual(expected, TaintedUtils.getMetrics(id, Verbosity.INFORMATION), 'Metrics expected to be equal')
+    assert.deepEqual(expected, TaintedUtils.getMetrics(id, Verbosity.DEBUG), 'Metrics expected to be equal')
+  })
 })


### PR DESCRIPTION
### What does this PR do?

Fix metrics verbosity precedence where higher verbosity levels should include the ones belonging to a lower one. 