### PR TITLE
Reduce Max allocated tainted objects and max ranges

### DIFF
--- a/src/iastlimits.h
+++ b/src/iastlimits.h
@@ -9,8 +9,8 @@
 #include <cstddef>
 namespace iast {
 struct Limits {
-    static const size_t MAX_RANGES = 100;
-    static const size_t MAX_TAINTED_OBJECTS = 16384;  // result of pow(2, 14);
+    static const size_t MAX_RANGES = 50;
+    static const size_t MAX_TAINTED_OBJECTS = 4096;  // result of pow(2, 12);
     static const size_t MAX_GLOBAL_TAINTED_RANGES = MAX_RANGES * MAX_TAINTED_OBJECTS;
     static const size_t MAX_TAINTED_RANGE_VECTORS = MAX_TAINTED_OBJECTS;
 };

--- a/test/js/new_tainted_string.spec.js
+++ b/test/js/new_tainted_string.spec.js
@@ -5,6 +5,8 @@
 const { TaintedUtils } = require('./util')
 const assert = require('assert')
 
+const MAX_TAINTED_OBJECTS = 4096
+
 describe('Taint strings', function () {
   const value = 'test'
   const id = TaintedUtils.createTransaction('1')
@@ -100,7 +102,7 @@ describe('Taint strings', function () {
 
   it('Max values', function () {
     let ret
-    const values = new Array(16384).fill('value')
+    const values = new Array(MAX_TAINTED_OBJECTS).fill('value')
 
     values.forEach((val, index, array) => {
       ret = TaintedUtils.newTaintedString(id, val, 'param', 'REQUEST')
@@ -124,7 +126,7 @@ describe('Taint strings', function () {
   it('Beyond Max values', function () {
     let ret
     // let id = '1';
-    const values = new Array(16384)
+    const values = new Array(MAX_TAINTED_OBJECTS)
     for (let i = 0; i < values.length; i++) {
       values[i] = i.toString()
       ret = TaintedUtils.newTaintedString(id, values[i], 'param', 'REQUEST')
@@ -133,7 +135,7 @@ describe('Taint strings', function () {
       assert.strictEqual(ret, true, 'Unexpected value')
     }
 
-    // element 16385
+    // element MAX_TAINTED_OBJECTS + 1
     const beyondLimit = 'beyond'
     ret = TaintedUtils.newTaintedString(id, beyondLimit, 'param', 'REQUEST')
     assert.strictEqual(ret, 'beyond', 'Unexpected value')


### PR DESCRIPTION
### What does this PR do?

Reduce the maximum number of concurrent tainted objects and ranges allocated in memory.

### Motivation

As per the current implementation, memory consumption increases a lot when using it in the tracer due to the preallocation of tainted objects in the pool. 

### Additional Notes

This is a first approach to reduce memory consumption.

### Checklist

- [x] Unit tests have been updated and pass
