### PR TITLE
Fix cpp-test-libc job in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,10 +70,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: mikepenz/action-junit-report@v3
       - run: docker build -t cpputest-libc --build-arg TAG=${{ matrix.alpine.tag }} -f ./docker/${{ matrix.target.dockerfile }} .
       - run: docker run --name test-libc cpputest-libc
       - run: docker cp test-libc:/build/test/cpputest/results/ .
+      - uses: mikepenz/action-junit-report@v3
         if: always()
         with:
           report_paths: '**/results/cpputest_*.xml'


### PR DESCRIPTION
### What does this PR do?

Fixes `cpp-test-libc` job in `build` workflow to match `pull-request` workflow
