### PR TITLE
Update alpine version in order to get the official repository working.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         alpine:
-          - tag: 2.7
+          - tag: 3.8
           - tag: 3.18
           - tag: latest
         target:


### PR DESCRIPTION
### What does this PR do?
Update alpine versions in the cpputest in order to avoid failures in package installation due to deprecated repositories.