### PR TITLE
Julio/create release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,4 +71,4 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'
-      - run: npm publish --dry-run
+      - run: npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    branches:
-      - v[0-9]+.x
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 jobs:
   build:
     uses: Datadog/action-prebuildify/.github/workflows/build.yml@main
@@ -71,9 +71,4 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'
-      - run: npm publish
-      - uses: codex-team/action-nodejs-package-info@v1.1
-        id: package
-      - run: |
-          git tag v${{ steps.package.outputs.version }}
-          git push origin v${{ steps.package.outputs.version }}
+      - run: npm publish --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]*'
 jobs:
   build:
     uses: Datadog/action-prebuildify/.github/workflows/build.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 jobs:
   build:
     uses: Datadog/action-prebuildify/.github/workflows/build.yml@main
@@ -48,7 +48,7 @@ jobs:
           tag_name: v${{ steps.package.outputs.version }}
           release_name: Release ${{ steps.package.outputs.version }}
           body: |
-            Test release
+            Release
           draft: false
           prerelease: false
       - uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - v[0-9]+.x
-      - julio/create_release
-
 jobs:
   build:
     uses: Datadog/action-prebuildify/.github/workflows/build.yml@main
@@ -14,7 +12,7 @@ jobs:
       napi: false
       package-manager: 'npm'
       prebuild: 'node scripts/prebuild'
-      skip: 'linux-arm linux-arm64 linux-ia32 windows-ia32 windows-x64 macos-arm64'
+      skip: 'linux-arm linux-ia32'
       target-name: 'iastnativemethods'
 
   pack:
@@ -52,9 +50,8 @@ jobs:
             Test release
           draft: false
           prerelease: false
-      - run: ls -l
       - uses: actions/upload-release-asset@v1
-        env: 
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -74,7 +71,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'
-      - run: npm publish --dry-run
+      - run: npm publish
       - uses: codex-team/action-nodejs-package-info@v1.1
         id: package
       - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
   create_release:
     needs: pack
     runs-on: ubuntu-latest
-    environment: npm
+    environment: release
     steps:
       - uses: actions/checkout@v3
       - uses: codex-team/action-nodejs-package-info@v1.1
@@ -72,4 +72,4 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'
-      - run: npm publish --dry-run
+      - run: npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
   create_release:
     needs: pack
     runs-on: ubuntu-latest
+    environment: npm
     steps:
       - uses: actions/checkout@v3
       - uses: codex-team/action-nodejs-package-info@v1.1
@@ -71,4 +72,4 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'
-      - run: npm publish
+      - run: npm publish --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - v[0-9]+.x
+      - julio/create_release
 
 jobs:
   build:
@@ -13,22 +14,67 @@ jobs:
       napi: false
       package-manager: 'npm'
       prebuild: 'node scripts/prebuild'
-      skip: 'linux-arm linux-ia32'
+      skip: 'linux-arm linux-arm64 linux-ia32 windows-ia32 windows-x64 macos-arm64'
       target-name: 'iastnativemethods'
 
-  publish:
+  pack:
     needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+      - run: npm pack
+      - uses: codex-team/action-nodejs-package-info@v1
+        id: package
+      - uses: actions/upload-artifact@v3
+        with:
+          name: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}
+          path: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}.tgz
+
+  create_release:
+    needs: pack
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: codex-team/action-nodejs-package-info@v1.1
+        id: package
+      - uses: actions/download-artifact@v3
+        with:
+          name: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}
+      - uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.package.outputs.version }}
+          release_name: Release ${{ steps.package.outputs.version }}
+          body: |
+            Test release
+          draft: false
+          prerelease: false
+      - run: ls -l
+      - uses: actions/upload-release-asset@v1
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}.tgz
+          asset_name: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}
+          asset_content_type: application/tar+gzip
+
+  publish:
+    needs: pack
     runs-on: ubuntu-latest
     environment: npm
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'
-      - run: npm publish
+      - run: npm publish --dry-run
       - uses: codex-team/action-nodejs-package-info@v1.1
         id: package
       - run: |


### PR DESCRIPTION
### What does this PR do?

Do automatic releases upon tag creation:

- Tags must comply with the following regex: `v[0-9]+.[0-9]+.[0-9]*`
- `create_release` and `publish` jobs works under `release` and `npm` environments respectively.
- `release` and `npm` environments has rules and need approval before being executed.

### Additional information

Previous policy of using v1.x branch is deprecated and it's not used anymore to trigger any action.