### PR TITLE
Add support for secure marks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ declare module 'datadog-iast-taint-tracking' {
         start: number;
         end: number;
         iinfo: NativeInputInfo;
+        secureMarks: number;
         readonly ref?: string;
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,7 @@ declare module 'datadog-iast-taint-tracking' {
     export interface TaintedUtils {
         createTransaction(transactionId: string): string;
         newTaintedString(transactionId: string, original: string, paramName: string, type: string): string;
+        addSecureMarksToTaintedString(transactionId: string, taintedString: string, secureMarks: number): string;
         isTainted(transactionId: string, ...args: string[]): boolean;
         getMetrics(transactionId: string, telemetryVerbosity: number): Metrics;
         getRanges(transactionId: string, original: string): NativeTaintedRange[];

--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ try {
     newTaintedString (transactionId, original) {
       return original
     },
+    addSecureMarksToTaintedString (transactionId, original) {
+      return original
+    },
     isTainted () {
       return false
     },
@@ -55,6 +58,7 @@ try {
 
 const iastNativeMethods = {
   newTaintedString: addon.newTaintedString,
+  addSecureMarksToTaintedString: addon.addSecureMarksToTaintedString,
   isTainted: addon.isTainted,
   getMetrics: addon.getMetrics,
   getRanges: addon.getRanges,

--- a/src/api/concat.cc
+++ b/src/api/concat.cc
@@ -70,7 +70,7 @@ void TaintConcatOperator(const FunctionCallbackInfo<Value>& args) {
                             auto argRange = *it;
                             auto newRange = transaction->GetRange(offset + argRange->start
                                     , offset + argRange->end,
-                                    argRange->inputInfo);
+                                    argRange->inputInfo, argRange->secureMarks);
                             ranges->PushBack(newRange);
                         }
                     } else {

--- a/src/api/replace.cc
+++ b/src/api/replace.cc
@@ -58,7 +58,7 @@ inline void addReplacerRanges(Transaction* transaction,
             for (auto replacerIt = replacerRanges->begin(); replacerItEnd != replacerIt; replacerIt++) {
                 auto range = (*replacerIt);
                 newRanges->PushBack(transaction->GetRange(range->start + toReplaceStart,
-                            range->end + toReplaceStart, range->inputInfo));
+                            range->end + toReplaceStart, range->inputInfo, range->secureMarks));
             }
         }
     }
@@ -86,7 +86,8 @@ inline SharedRanges* adjustReplacementRanges(Transaction* transaction,
             if (range->end <= toReplaceStart) {
                 newRanges->PushBack(range);
             } else if (range->end > toReplaceStart) {
-                newRanges->PushBack(transaction->GetRange(range->start, toReplaceStart, range->inputInfo));
+                newRanges->PushBack(transaction->GetRange(range->start, toReplaceStart,
+                                                          range->inputInfo, range->secureMarks));
                 break;
             }
             ++subjectIt;
@@ -102,13 +103,13 @@ inline SharedRanges* adjustReplacementRanges(Transaction* transaction,
                 if (range->start <= toReplaceEnd) {
                     newRanges->PushBack(transaction->GetRange(toReplaceEnd + offset,
                                 range->end + offset,
-                                range->inputInfo));
+                                range->inputInfo, range->secureMarks));
                 } else if (offset == 0) {
                     newRanges->PushBack(range);
                 } else {
                     newRanges->PushBack(transaction->GetRange(range->start + offset,
                                 range->end + offset,
-                                range->inputInfo));
+                                range->inputInfo, range->secureMarks));
                 }
             }
             subjectIt++;
@@ -161,7 +162,7 @@ inline SharedRanges* adjustRegexReplacementRanges(Transaction* transaction,
                     if (start == range->start && end == range->end) {
                         newRanges->PushBack(range);
                     } else {
-                        newRanges->PushBack(transaction->GetRange(start, end, range->inputInfo));
+                        newRanges->PushBack(transaction->GetRange(start, end, range->inputInfo, range->secureMarks));
                     }
                 }
                 if (breakLoop) {
@@ -183,13 +184,13 @@ inline SharedRanges* adjustRegexReplacementRanges(Transaction* transaction,
             if (lastEnd < range->end) {
                 if (lastEnd > range->start) {
                     newRanges->PushBack(transaction->GetRange(lastEnd + offset, range->end + offset,
-                                range->inputInfo));
+                                range->inputInfo, range->secureMarks));
                 } else if (offset == 0) {
                     newRanges->PushBack(range);
                 } else {
                     newRanges->PushBack(
                             transaction->GetRange(range->start + offset, range->end + offset,
-                                range->inputInfo));
+                                range->inputInfo, range->secureMarks));
                 }
             }
             ++subjectIt;

--- a/src/api/string_methods.cc
+++ b/src/api/string_methods.cc
@@ -21,6 +21,7 @@
 #include "../gc/gc.h"
 #include "../iast.h"
 #include "v8.h"
+#include "../utils/string_utils.h"
 
 using v8::Exception;
 using v8::FunctionCallbackInfo;
@@ -98,7 +99,7 @@ void NewTaintedString(const FunctionCallbackInfo<Value>& args) {
 
         auto range = transaction->GetRange(0,
                 utils::GetLength(args.GetIsolate(), parameterValue),
-                inputInfo);
+                inputInfo, 0);
         auto ranges = transaction->GetSharedVectorRange();
         ranges->PushBack(range);
         auto stringPointer = utils::GetLocalStringPointer(parameterValue);
@@ -112,6 +113,74 @@ void NewTaintedString(const FunctionCallbackInfo<Value>& args) {
     }
 }
 
+void AddSecureMarksToTaintedString(const FunctionCallbackInfo<Value>& args) {
+    auto isolate = args.GetIsolate();
+    if (args.Length() < 3) {
+        isolate->ThrowException(v8::Exception::TypeError(
+                v8::String::NewFromUtf8(isolate,
+                                        "Wrong number of arguments",
+                                        v8::NewStringType::kNormal).ToLocalChecked()));
+        return;
+    }
+
+    if (!(args[0]->IsString()) || !Local<String>::Cast(args[0])->Length()) {
+        // invalid transaction id, return taintedString
+        args.GetReturnValue().Set(args[1]);
+        return;
+    }
+
+    if (!(args[1]->IsString())) {
+        // invalid taintedString, return it
+        args.GetReturnValue().Set(args[1]);
+        return;
+    }
+
+    auto context = isolate->GetCurrentContext();
+
+    auto transactionIdArgument = args[0];
+    auto taintedString = args[1];
+    auto secureMarksArgument = args[2];
+
+    args.GetReturnValue().Set(taintedString);
+
+    int secureMarks = secureMarksArgument->IntegerValue(context).FromJust();
+    if (secureMarks == 0) {
+        // not secure marks to add
+        return;
+    }
+
+    uintptr_t transactionId = utils::GetLocalStringPointer(transactionIdArgument);
+    try {
+        auto transaction = NewTransaction(transactionId);
+        if (transaction == nullptr) {
+            return;
+        }
+        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalStringPointer(taintedString));
+        if (!taintedObj) {
+            // It is not a tainted object, do nothing
+            return;
+        }
+
+        auto newRanges = transaction->GetSharedVectorRange();
+        if (newRanges) {
+            auto oRanges = taintedObj->getRanges();
+            taintedString = tainted::NewStringInstanceForNewTaintedObject
+                    (isolate, v8::Local<v8::String>::Cast(taintedString));
+            for (auto it = oRanges->begin(); it != oRanges->end(); ++it) {
+                auto oRange = *it;
+                int start = oRange->start;
+                int end = oRange->end;
+                int oSecureMarks = oRange->secureMarks;
+                newRanges->PushBack(transaction->GetRange(start, end, oRange->inputInfo, oSecureMarks | secureMarks));
+            }
+            transaction->AddTainted(utils::GetLocalStringPointer(taintedString), newRanges, taintedString);
+            args.GetReturnValue().Set(taintedString);
+        }
+    } catch (const std::bad_alloc& err) {
+    } catch (const container::QueuedPoolBadAlloc& err) {
+    } catch (const container::PoolBadAlloc& err) {
+    }
+}
 void IsTainted(const FunctionCallbackInfo<Value>& args) {
     auto argsLength = args.Length();
     if (argsLength < 2) {
@@ -149,7 +218,6 @@ void GetRanges(const FunctionCallbackInfo<Value>& args) {
                 NewStringType::kNormal).ToLocalChecked()));
         return;
     }
-
     uintptr_t transactionId = utils::GetLocalStringPointer(args[0]);
     auto transaction = GetTransaction(transactionId);
     if (transaction != nullptr) {
@@ -206,6 +274,7 @@ void SetMaxTransactions(const FunctionCallbackInfo<Value>& args) {
 void StringMethods::Init(Local<Object> exports) {
     NODE_SET_METHOD(exports, "createTransaction", CreateTransaction);
     NODE_SET_METHOD(exports, "newTaintedString", NewTaintedString);
+    NODE_SET_METHOD(exports, "addSecureMarksToTaintedString", AddSecureMarksToTaintedString);
     NODE_SET_METHOD(exports, "isTainted", IsTainted);  // TODO(julio): support several objects.
     NODE_SET_METHOD(exports, "getRanges", GetRanges);
     NODE_SET_METHOD(exports, "removeTransaction", DeleteTransaction);

--- a/src/api/trim.cc
+++ b/src/api/trim.cc
@@ -85,7 +85,7 @@ void TaintTrimOperator(const FunctionCallbackInfo<Value>& args) {
             }
 
             if (newRangeEnd > newRangeStart) {
-                auto newRange = transaction->GetRange(newRangeStart, newRangeEnd, range->inputInfo);
+                auto newRange = transaction->GetRange(newRangeStart, newRangeEnd, range->inputInfo, range->secureMarks);
                 resultRanges->PushBack(newRange);
             }
         }
@@ -150,7 +150,7 @@ void TaintTrimEndOperator(const FunctionCallbackInfo<Value>& args) {
             }
 
             if (newRangeEnd > newRangeStart) {
-                auto newRange = transaction->GetRange(newRangeStart, newRangeEnd, range->inputInfo);
+                auto newRange = transaction->GetRange(newRangeStart, newRangeEnd, range->inputInfo, range->secureMarks);
                 resultRanges->PushBack(newRange);
             }
         }

--- a/src/tainted/range.cc
+++ b/src/tainted/range.cc
@@ -19,16 +19,20 @@ bool labelsDefined = false;
 v8::Persistent<v8::Value> startLabel;
 v8::Persistent<v8::Value> endLabel;
 v8::Persistent<v8::Value> iinfoLabel;
-Range::Range(int start, int end, InputInfo *inputInfo) {
+v8::Persistent<v8::Value> secureMarksLabel;
+
+Range::Range(int start, int end, InputInfo *inputInfo, int secureMarks) {
     this->start = start;
     this->end = end;
     this->inputInfo = inputInfo;
+    this->secureMarks = secureMarks;
 }
 
 Range::Range(const Range& range) {
     this->start = range.start;
     this->end = range.end;
     this->inputInfo = range.inputInfo;
+    this->secureMarks = range.secureMarks;
 }
 
 Range::~Range() {}
@@ -39,18 +43,22 @@ v8::Local<v8::Object> Range::toJSObject(v8::Isolate* isolate) {
     v8::Local<v8::Value> startLabelLocal;
     v8::Local<v8::Value> endLabelLocal;
     v8::Local<v8::Value> iinfoLabelLocal;
+    v8::Local<v8::Value> secureMarksLabelLocal;
     if (!labelsDefined) {
         startLabelLocal = utils::NewV8String(isolate, "start");
         endLabelLocal = utils::NewV8String(isolate, "end");
         iinfoLabelLocal = utils::NewV8String(isolate, "iinfo");
+        secureMarksLabelLocal = utils::NewV8String(isolate, "secureMarks");
         startLabel.Reset(isolate, startLabelLocal);
         endLabel.Reset(isolate, endLabelLocal);
         iinfoLabel.Reset(isolate, iinfoLabelLocal);
+        secureMarksLabel.Reset(isolate, secureMarksLabelLocal);
         labelsDefined = true;
     } else {
         startLabelLocal = v8::Local<v8::Value>::New(isolate, startLabel);
         endLabelLocal = v8::Local<v8::Value>::New(isolate, endLabel);
         iinfoLabelLocal = v8::Local<v8::Value>::New(isolate, iinfoLabel);
+        secureMarksLabelLocal = v8::Local<v8::Value>::New(isolate, secureMarksLabel);
     }
 
     taintedRangev8Obj->Set(context, startLabelLocal, v8::Number::New(isolate, this->start)).Check();
@@ -58,6 +66,7 @@ v8::Local<v8::Object> Range::toJSObject(v8::Isolate* isolate) {
     taintedRangev8Obj->Set(context,
             iinfoLabelLocal,
             GetJsObjectFromInputInfo(isolate, context, this->inputInfo)).Check();
+    taintedRangev8Obj->Set(context, secureMarksLabelLocal, v8::Number::New(isolate, this->secureMarks)).Check();
 
     return taintedRangev8Obj;
 }

--- a/src/tainted/range.cc
+++ b/src/tainted/range.cc
@@ -21,7 +21,7 @@ v8::Persistent<v8::Value> endLabel;
 v8::Persistent<v8::Value> iinfoLabel;
 v8::Persistent<v8::Value> secureMarksLabel;
 
-Range::Range(int start, int end, InputInfo *inputInfo, int secureMarks) {
+Range::Range(int start, int end, InputInfo *inputInfo, secure_marks_t secureMarks) {
     this->start = start;
     this->end = end;
     this->inputInfo = inputInfo;

--- a/src/tainted/range.h
+++ b/src/tainted/range.h
@@ -13,13 +13,14 @@ namespace iast {
 namespace tainted {
 class Range {
  public:
-    explicit Range(int start, int end, InputInfo *inputInfo);
+    explicit Range(int start, int end, InputInfo *inputInfo, int secureMarks);
     Range(const Range& taintedRange);
     ~Range();
     v8::Local<v8::Object> toJSObject(v8::Isolate* isolate);
     int start;
     int end;
     InputInfo* inputInfo;
+    int secureMarks;
 };
 }    // namespace tainted
 }    // namespace iast

--- a/src/tainted/range.h
+++ b/src/tainted/range.h
@@ -11,16 +11,17 @@
 
 namespace iast {
 namespace tainted {
+using secure_marks_t = uint16_t;
 class Range {
  public:
-    explicit Range(int start, int end, InputInfo *inputInfo, int secureMarks);
+    explicit Range(int start, int end, InputInfo *inputInfo, secure_marks_t secureMarks);
     Range(const Range& taintedRange);
     ~Range();
     v8::Local<v8::Object> toJSObject(v8::Isolate* isolate);
     int start;
     int end;
     InputInfo* inputInfo;
-    int secureMarks;
+    secure_marks_t secureMarks;
 };
 }    // namespace tainted
 }    // namespace iast

--- a/src/tainted/string_resource.h
+++ b/src/tainted/string_resource.h
@@ -5,6 +5,7 @@
 #ifndef SRC_TAINTED_STRING_RESOURCE_H_
 #define SRC_TAINTED_STRING_RESOURCE_H_
 #include <node.h>
+#include <string>
 
 namespace iast {
 namespace tainted {
@@ -27,6 +28,17 @@ class StringResource : public v8::String::ExternalStringResource {
 };
 
 v8::Local<v8::String> NewExternalString(v8::Isolate* isolate, v8::Local<v8::Value> obj);
+inline v8::Local<v8::String> NewStringInstanceForNewTaintedObject(v8::Isolate* isolate, v8::Local<v8::String> obj) {
+    // if string length < 10 then make a new one in order to avoid cache issues.
+    int len =  obj->Length();
+    if (len == 1) {
+        return tainted::NewExternalString(isolate, obj);
+    } else {
+        v8::String::Utf8Value param1(isolate, obj);
+        std::string cppStr(*param1);
+        return v8::String::NewFromUtf8(isolate, cppStr.c_str(), v8::NewStringType::kNormal).ToLocalChecked();
+    }
+}
 }  // namespace tainted
 }  // namespace iast
 #endif  // SRC_TAINTED_STRING_RESOURCE_H_

--- a/src/tainted/string_resource.h
+++ b/src/tainted/string_resource.h
@@ -29,7 +29,6 @@ class StringResource : public v8::String::ExternalStringResource {
 
 v8::Local<v8::String> NewExternalString(v8::Isolate* isolate, v8::Local<v8::Value> obj);
 inline v8::Local<v8::String> NewStringInstanceForNewTaintedObject(v8::Isolate* isolate, v8::Local<v8::String> obj) {
-    // if string length < 10 then make a new one in order to avoid cache issues.
     int len =  obj->Length();
     if (len == 1) {
         return tainted::NewExternalString(isolate, obj);

--- a/src/tainted/transaction.h
+++ b/src/tainted/transaction.h
@@ -39,7 +39,7 @@ class Transaction {
             v8::Local<v8::Value> parameterValue,
             v8::Local<v8::Value> type);
 
-    Range* GetRange(int start, int end, InputInfo *inputInfo, int secureMarks) {
+    Range* GetRange(int start, int end, InputInfo *inputInfo, secure_marks_t secureMarks) {
         return _rangesPool.Pop(start, end, inputInfo, secureMarks);
     }
 

--- a/src/tainted/transaction.h
+++ b/src/tainted/transaction.h
@@ -39,8 +39,8 @@ class Transaction {
             v8::Local<v8::Value> parameterValue,
             v8::Local<v8::Value> type);
 
-    Range* GetRange(int start, int end, InputInfo *inputInfo) {
-        return _rangesPool.Pop(start, end, inputInfo);
+    Range* GetRange(int start, int end, InputInfo *inputInfo, int secureMarks) {
+        return _rangesPool.Pop(start, end, inputInfo, secureMarks);
     }
 
     SharedRanges* GetSharedVectorRange(void) {

--- a/src/utils/propagation.cc
+++ b/src/utils/propagation.cc
@@ -58,7 +58,7 @@ SharedRanges* getRangesInSlice(Transaction* transaction, TaintedObject* obj, int
             newRanges = transaction->GetSharedVectorRange();
         }
 
-        newRanges->PushBack(transaction->GetRange(start, end, oRange->inputInfo));
+        newRanges->PushBack(transaction->GetRange(start, end, oRange->inputInfo, oRange->secureMarks));
     }
     return newRanges;
 }

--- a/test/js/concat.spec.js
+++ b/test/js/concat.spec.js
@@ -36,6 +36,23 @@ describe('Plus operator', function () {
     assert.equal(true, TaintedUtils.isTainted(id, ret), 'Unexpected value')
   })
 
+  it('Secure marks are inherited', () => {
+    let op1 = 'hello'
+    let op2 = ' world'
+    op1 = TaintedUtils.newTaintedString(id, op1, 'param', 'REQUEST')
+    op2 = TaintedUtils.newTaintedString(id, op2, 'param', 'REQUEST')
+    op1 = TaintedUtils.addSecureMarksToTaintedString(id, op1, 0b0110)
+    op2 = TaintedUtils.addSecureMarksToTaintedString(id, op2, 0b1001)
+
+    let ret = op1 + op2
+    ret = TaintedUtils.concat(id, ret, op1, op2)
+
+    const ranges = TaintedUtils.getRanges(id, ret)
+    assert.equal(ranges.length, 2)
+    assert.equal(ranges[0].secureMarks, 0b0110)
+    assert.equal(ranges[1].secureMarks, 0b1001)
+  })
+
   it('Check ranges', function () {
     let op1 = 'hello'
     let op2 = ' world'
@@ -50,7 +67,8 @@ describe('Plus operator', function () {
             parameterName: 'param',
             parameterValue: 'hello',
             type: 'REQUEST'
-          }
+          },
+        secureMarks: 0
       },
       {
         start: op1.length,
@@ -60,7 +78,8 @@ describe('Plus operator', function () {
             parameterName: 'param',
             parameterValue: ' world',
             type: 'REQUEST'
-          }
+          },
+        secureMarks: 0
       }
     ]
 
@@ -93,7 +112,8 @@ describe('Plus operator', function () {
             parameterName: 'param',
             parameterValue: 'hello',
             type: 'REQUEST'
-          }
+          },
+        secureMarks: 0
       }
     ]
 
@@ -122,7 +142,8 @@ describe('Plus operator', function () {
             parameterName: 'param',
             parameterValue: ' world',
             type: 'REQUEST'
-          }
+          },
+        secureMarks: 0
       }
     ]
 

--- a/test/js/get_ranges.spec.js
+++ b/test/js/get_ranges.spec.js
@@ -22,7 +22,8 @@ describe('Ranges', function () {
         parameterName: 'param',
         parameterValue: 'test',
         type: 'REQUEST'
-      }
+      },
+      secureMarks: 0
     }]
     const taintedValue = TaintedUtils.newTaintedString(id, value, param, 'REQUEST')
 

--- a/test/js/replace.spec.js
+++ b/test/js/replace.spec.js
@@ -195,6 +195,24 @@ describe('Replace', function () {
         assert.equal(formatTaintedValue(id, result), expected, 'Unexpected vale')
       })
     })
+
+    it('Secure marks are inherited', () => {
+      let op1 = 'helloREPLACEworld'
+      let op2 = ' '
+      op1 = TaintedUtils.newTaintedString(id, op1, 'param1', 'REQUEST')
+      op2 = TaintedUtils.newTaintedString(id, op2, 'param2', 'REQUEST')
+      op1 = TaintedUtils.addSecureMarksToTaintedString(id, op1, 0b0110)
+      op2 = TaintedUtils.addSecureMarksToTaintedString(id, op2, 0b1001)
+
+      let result = op1.replace('REPLACE', op2)
+      result = TaintedUtils.replace(id, result, op1, 'REPLACE', op2)
+
+      const ranges = TaintedUtils.getRanges(id, result)
+      assert.equal(ranges.length, 3)
+      assert.equal(ranges[0].secureMarks, 0b0110)
+      assert.equal(ranges[1].secureMarks, 0b1001)
+      assert.equal(ranges[2].secureMarks, 0b0110)
+    })
   })
 
   describe('when the matcher is a Regex and replacer is string without special char', () => {

--- a/test/js/secure-marks.spec.js
+++ b/test/js/secure-marks.spec.js
@@ -1,0 +1,109 @@
+/**
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+ **/
+'use strict'
+
+const { TaintedUtils } = require('./util')
+const assert = require('assert')
+describe('Secure marks', function () {
+  const id = '666'
+  const value = 'test'
+  const param = 'param'
+
+  afterEach(function () {
+    TaintedUtils.removeTransaction(id)
+  })
+
+  it('By default securemarks is 0', () => {
+    const taintedValue = TaintedUtils.newTaintedString(id, value, param, 'REQUEST')
+    const ranges = TaintedUtils.getRanges(id, taintedValue)
+
+    assert.equal(ranges.length, 1)
+    assert.equal(ranges[0].secureMarks, 0)
+  })
+
+  it('Add secure marks does not modify original ranges', () => {
+    const originalTaintedValue = TaintedUtils.newTaintedString(id, value, param, 'REQUEST')
+    const taintedValueWithSecureMarks = TaintedUtils.addSecureMarksToTaintedString(id, originalTaintedValue, 0b1)
+    const oRanges = TaintedUtils.getRanges(id, originalTaintedValue)
+    const markedRanges = TaintedUtils.getRanges(id, taintedValueWithSecureMarks)
+
+    assert.equal(markedRanges.length, 0b1)
+    assert.equal(markedRanges[0].secureMarks, 1)
+
+    assert.equal(oRanges.length, 1)
+    assert.equal(oRanges[0].secureMarks, 0)
+  })
+
+  it('Multiple secure marks', () => {
+    const originalTaintedValue = TaintedUtils.newTaintedString(id, value, param, 'REQUEST')
+
+    const taintedValueWithSecureMarks1 = TaintedUtils.addSecureMarksToTaintedString(id, originalTaintedValue, 0b001)
+    const taintedValueWithSecureMarks2 = TaintedUtils.addSecureMarksToTaintedString(id,
+      taintedValueWithSecureMarks1, 0b100)
+    const taintedValueWithSecureMarks3 = TaintedUtils.addSecureMarksToTaintedString(id,
+      taintedValueWithSecureMarks2, 0b010)
+
+    const oRanges = TaintedUtils.getRanges(id, originalTaintedValue)
+    const markedRanges1 = TaintedUtils.getRanges(id, taintedValueWithSecureMarks1)
+    const markedRanges2 = TaintedUtils.getRanges(id, taintedValueWithSecureMarks2)
+    const markedRanges3 = TaintedUtils.getRanges(id, taintedValueWithSecureMarks3)
+
+    assert.equal(markedRanges1.length, 1)
+    assert.equal(markedRanges1[0].secureMarks, 0b1)
+
+    assert.equal(markedRanges2.length, 1)
+    assert.equal(markedRanges2[0].secureMarks, 0b101)
+
+    assert.equal(markedRanges3.length, 1)
+    assert.equal(markedRanges3[0].secureMarks, 0b111)
+
+    assert.equal(oRanges.length, 1)
+    assert.equal(oRanges[0].secureMarks, 0)
+  })
+
+  it('Secure marks apply to all ranges', () => {
+    const taintedValue1 = TaintedUtils.newTaintedString(id, 'firstRange', param, 'REQUEST')
+    const taintedValue2 = TaintedUtils.newTaintedString(id, 'secondRange', param, 'REQUEST')
+    let originalTaintedValue = TaintedUtils.concat(id, taintedValue1 + ' ', taintedValue1, ' ')
+    originalTaintedValue = TaintedUtils.concat(id, originalTaintedValue + taintedValue2,
+      originalTaintedValue, taintedValue2)
+    assert.equal(originalTaintedValue, 'firstRange secondRange')
+
+    const taintedValueWithSecureMarks1 = TaintedUtils.addSecureMarksToTaintedString(id, originalTaintedValue, 0b001)
+    const taintedValueWithSecureMarks2 = TaintedUtils.addSecureMarksToTaintedString(id,
+      taintedValueWithSecureMarks1, 0b100)
+
+    const oRanges = TaintedUtils.getRanges(id, originalTaintedValue)
+    const markedRanges1 = TaintedUtils.getRanges(id, taintedValueWithSecureMarks1)
+    const markedRanges2 = TaintedUtils.getRanges(id, taintedValueWithSecureMarks2)
+
+    assert.equal(markedRanges1.length, 2)
+    assert.equal(markedRanges1[1].secureMarks, 0b1)
+    assert.equal(markedRanges1[1].secureMarks, 0b1)
+
+    assert.equal(markedRanges2.length, 2)
+    assert.equal(markedRanges2[1].secureMarks, 0b101)
+    assert.equal(markedRanges2[1].secureMarks, 0b101)
+
+    assert.equal(oRanges.length, 2)
+    assert.equal(oRanges[0].secureMarks, 0)
+    assert.equal(oRanges[1].secureMarks, 0)
+  })
+
+  it('Secure marks are inherited in string modifications', () => {
+    const originalTaintedValue = TaintedUtils.newTaintedString(id, 'range1TOREPLACErange2', param, 'REQUEST')
+    const taintedValueWithSecureMarks = TaintedUtils.addSecureMarksToTaintedString(id, originalTaintedValue, 0b1)
+
+    let result = taintedValueWithSecureMarks.replace('TOREPLACE', ' ')
+    result = TaintedUtils.replace(id, result, taintedValueWithSecureMarks, 'TOREPLACE', ' ')
+    assert.equal(result, 'range1 range2')
+
+    const markedRanges1 = TaintedUtils.getRanges(id, result)
+
+    assert.equal(markedRanges1.length, 2)
+    assert.equal(markedRanges1[1].secureMarks, 0b1)
+    assert.equal(markedRanges1[1].secureMarks, 0b1)
+  })
+})

--- a/test/js/slice.spec.js
+++ b/test/js/slice.spec.js
@@ -177,4 +177,17 @@ describe('Slice', function () {
       })
     })
   })
+
+  it('Secure marks are inherited', () => {
+    let op1 = 'hello world'
+    op1 = TaintedUtils.newTaintedString(id, op1, 'param1', 'REQUEST')
+    op1 = TaintedUtils.addSecureMarksToTaintedString(id, op1, 0b0110)
+
+    let result = op1.slice(6)
+    result = TaintedUtils.slice(id, result, op1, 6)
+
+    const ranges = TaintedUtils.getRanges(id, result)
+    assert.equal(ranges.length, 1)
+    assert.equal(ranges[0].secureMarks, 0b0110)
+  })
 })

--- a/test/js/substr.spec.js
+++ b/test/js/substr.spec.js
@@ -209,7 +209,8 @@ describe('Substr method', function () {
                   parameterName: 'param',
                   parameterValue: 'hello',
                   type: 'REQUEST'
-                }
+                },
+        secureMarks: 0
       }
     ]
 
@@ -239,6 +240,19 @@ describe('Substr method', function () {
 
     assert.equal(res, ret, 'Unexpected vale')
     assert.equal(false, TaintedUtils.isTainted(id, ret), 'Unexpected value')
+  })
+
+  it('Secure marks are inherited', () => {
+    let op1 = 'hello world'
+    op1 = TaintedUtils.newTaintedString(id, op1, 'param1', 'REQUEST')
+    op1 = TaintedUtils.addSecureMarksToTaintedString(id, op1, 0b0110)
+
+    let result = op1.substr(6)
+    result = TaintedUtils.substr(id, result, op1, 6)
+
+    const ranges = TaintedUtils.getRanges(id, result)
+    assert.equal(ranges.length, 1)
+    assert.equal(ranges[0].secureMarks, 0b0110)
   })
 })
 

--- a/test/js/substring.spec.js
+++ b/test/js/substring.spec.js
@@ -209,7 +209,8 @@ describe('Substring method', function () {
                   parameterName: 'param',
                   parameterValue: 'hello',
                   type: 'REQUEST'
-                }
+                },
+        secureMarks: 0
       }
     ]
 
@@ -239,6 +240,19 @@ describe('Substring method', function () {
 
     assert.equal(res, ret, 'Unexpected vale')
     assert.equal(false, TaintedUtils.isTainted(id, ret), 'Unexpected value')
+  })
+
+  it('Secure marks are inherited', () => {
+    let op1 = 'hello world'
+    op1 = TaintedUtils.newTaintedString(id, op1, 'param1', 'REQUEST')
+    op1 = TaintedUtils.addSecureMarksToTaintedString(id, op1, 0b0110)
+
+    let result = op1.substring(6)
+    result = TaintedUtils.substring(id, result, op1, 6)
+
+    const ranges = TaintedUtils.getRanges(id, result)
+    assert.equal(ranges.length, 1)
+    assert.equal(ranges[0].secureMarks, 0b0110)
   })
 })
 

--- a/test/js/trim.spec.js
+++ b/test/js/trim.spec.js
@@ -327,6 +327,19 @@ describe('Trim operator', function () {
       testTrimNoTaintedResult(String.prototype.trim, TaintedUtils.trim)
     })
 
+    it('Secure marks are inherited', () => {
+      let op1 = '   hello world   '
+      op1 = TaintedUtils.newTaintedString(id, op1, 'param1', 'REQUEST')
+      op1 = TaintedUtils.addSecureMarksToTaintedString(id, op1, 0b0110)
+
+      let result = op1.trim()
+      result = TaintedUtils.trim(id, result, op1)
+
+      const ranges = TaintedUtils.getRanges(id, result)
+      assert.equal(ranges.length, 1)
+      assert.equal(ranges[0].secureMarks, 0b0110)
+    })
+
     describe('Check result not tainted when no ranges left', function () {
       noTaintTestCases.trim.forEach((testString) => {
         it(`Test ${testString}`, () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add secure marks field to be able to mark a tainted string as secure for some vulnerabilities.

The idea for the use of these secure marks is with bit modifications. For example, if secure mark for NOSQL_INJECTION_MONGODB is `0b001` and for SQL_INJECTION is `0b100`, dd-trace-js code will add two secure marks, one for mongo and other for sqli.
```
const NOSQL_INJECTION_MONGODB_SECURE_MARK = 0b001
const SQL_INJECTION_SECURE_MARK = 0b100
TaintedUtils.addSecureMarksToTaintedString(transactionId, sanitizedString, NOSQL_INJECTION_MONGODB_SECURE_MARK)
/// more code...
TaintedUtils.addSecureMarksToTaintedString(transactionId, sanitizedString, SQL_INJECTION_SECURE_MARK)
```
Each secure mark should be a 2^x number, all bits in `0` and one in `1`
### Motivation
<!-- What inspired you to submit this pull request? -->
We will need this feature in dd-trace-js to be able to mark as secure tainted string when some validation like sanitize happens. 

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Unit tests have been updated and pass

