### PR TITLE
Fix publish.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         id: package
       - uses: actions/upload-artifact@v3
         with:
-          name: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}
+          name: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}.tgz
           path: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}.tgz
 
   create_release:
@@ -68,8 +68,12 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v3
+      - uses: codex-team/action-nodejs-package-info@v1.1
+        id: package
       - uses: actions/download-artifact@v3
+        with:
+          name: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}.tgz
       - uses: actions/setup-node@v3
         with:
           registry-url: 'https://registry.npmjs.org'
-      - run: npm publish
+      - run: npm publish ./datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@datadog/native-iast-taint-tracking",
       "version": "1.6.0",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "node-gyp-build": "^3.9.0"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:arm": "node-gyp configure -arch=arm64 && node-gyp build -arch=arm64",
     "build:asan": "node-gyp configure && CXXFLAGS=\"-g -O0 -fsanitize=address\" LDFLAGS=\"-fsanitize=address\" node-gyp build",
     "build:valgrind": "node-gyp configure && CXXFLAGS=\"-g -O0\" node-gyp build",
+    "install": "exit 0",
     "lint": "eslint . -c ./.eslintrc.json",
     "postbuild": "node ./scripts/pack.js",
     "postbuild:asan": "npm run postbuild",


### PR DESCRIPTION
### What does this PR do?

This PR avoids setting the `gypfile` property on npm registry. This property prevents the package from being built when a using private proxy registry.
