### PR TITLE
Fix NewTransaction method

### DIFF
--- a/src/api/string_methods.cc
+++ b/src/api/string_methods.cc
@@ -151,7 +151,8 @@ void AddSecureMarksToTaintedString(const FunctionCallbackInfo<Value>& args) {
     }
 
     uintptr_t transactionId = utils::GetLocalStringPointer(transactionIdArgument);
-    auto transaction = NewTransaction(transactionId);
+
+    auto transaction = GetTransaction(transactionId);
     if (transaction == nullptr) {
         return;
     }

--- a/src/transaction_manager.h
+++ b/src/transaction_manager.h
@@ -20,12 +20,12 @@ class TransactionManager {
     void operator=(TransactionManager const&) = delete;
 
     T* New(U id) {
-        if (_map.size() >= _maxItems) {
-            return nullptr;
-        }
-
         auto found = _map.find(id);
         if (found == _map.end()) {
+            if (_map.size() >= _maxItems) {
+                return nullptr;
+            }
+
             T* item = _pool.Pop(id);
             _map[id] = item;
             return item;

--- a/test/js/new_tainted_string.spec.js
+++ b/test/js/new_tainted_string.spec.js
@@ -11,8 +11,16 @@ describe('Taint strings', function () {
   const value = 'test'
   const id = TaintedUtils.createTransaction('1')
 
+  before(() => {
+    TaintedUtils.setMaxTransactions(1)
+  })
+
   afterEach(function () {
     TaintedUtils.removeTransaction(id)
+  })
+
+  after(() => {
+    TaintedUtils.setMaxTransactions(2)
   })
 
   it('Taint new string with undefined transaction', function () {


### PR DESCRIPTION
### What does this PR do?

NewTransaction method is expected to create new transaction if it does not exist, in this PR I am changing the point where the max size of the transactions was checked. Now we are not checking it if it doesn't need to create new one.

### Motivation
On create newTaintedString, we were calling to NewTransaction method, and it was failing when the max size of transactions were already created, even when it doesn't need it.

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Unit tests have been updated and pass

