### PR TITLE
Do not taint empty strings

### DIFF
--- a/src/api/slice.cc
+++ b/src/api/slice.cc
@@ -38,13 +38,14 @@ void slice(const FunctionCallbackInfo<Value>& args) {
     auto context = isolate->GetCurrentContext();
     auto vResult = args[1];
     auto vSubject = args[2];
-    int sliceStart = args[3]->IntegerValue(context).FromJust();
 
     int len =  v8::Local<v8::String>::Cast(vResult)->Length();
     if (len == 0) {
         args.GetReturnValue().Set(vResult);
         return;
     }
+
+    int sliceStart = args[3]->IntegerValue(context).FromJust();
 
     Transaction* transaction = GetTransaction(GetLocalStringPointer(args[0]));
     if (transaction == nullptr) {

--- a/src/api/slice.cc
+++ b/src/api/slice.cc
@@ -40,6 +40,12 @@ void slice(const FunctionCallbackInfo<Value>& args) {
     auto vSubject = args[2];
     int sliceStart = args[3]->IntegerValue(context).FromJust();
 
+    int len =  v8::Local<v8::String>::Cast(vResult)->Length();
+    if (len == 0) {
+        args.GetReturnValue().Set(vResult);
+        return;
+    }
+
     Transaction* transaction = GetTransaction(GetLocalStringPointer(args[0]));
     if (transaction == nullptr) {
         args.GetReturnValue().Set(vResult);

--- a/src/api/string_methods.cc
+++ b/src/api/string_methods.cc
@@ -71,7 +71,10 @@ void NewTaintedString(const FunctionCallbackInfo<Value>& args) {
 
     // if string length < 10 then make a new one in order to avoid cache issues.
     int len =  v8::Local<v8::String>::Cast(args[1])->Length();
-    if (len == 1) {
+    if (len == 0) {
+        args.GetReturnValue().Set(args[1]);
+        return;
+    } else if (len == 1) {
         parameterValue = tainted::NewExternalString(isolate, args[1]);
     } else if (len < 10) {
         v8::String::Utf8Value param1(isolate, args[1]);

--- a/test/js/new_tainted_string.spec.js
+++ b/test/js/new_tainted_string.spec.js
@@ -108,6 +108,16 @@ describe('Taint strings', function () {
     assert.strictEqual(ret, false, 'Unexpected value')
   })
 
+  it('Do not taint empty string', function () {
+    let ret
+    const value = ''
+
+    ret = TaintedUtils.newTaintedString(id, value, 'param', 'REQUEST')
+    assert.strictEqual(ret, '', 'Unexpected value')
+    ret = TaintedUtils.isTainted(id, ret)
+    assert.strictEqual(ret, false, 'Unexpected value')
+  })
+
   it('Max values', function () {
     let ret
     const values = new Array(MAX_TAINTED_OBJECTS).fill('value')

--- a/test/js/slice.spec.js
+++ b/test/js/slice.spec.js
@@ -178,6 +178,16 @@ describe('Slice', function () {
     })
   })
 
+  it('Check slice empty string result', function () {
+    let op1 = 'hello world'
+    op1 = TaintedUtils.newTaintedString(id, op1, 'param1', 'REQUEST')
+
+    let result = op1.slice(6, 6)
+    result = TaintedUtils.slice(id, result, op1, 6)
+
+    assert.equal(TaintedUtils.isTainted(id, result), false, 'Empty string is tainted')
+  })
+
   it('Secure marks are inherited', () => {
     let op1 = 'hello world'
     op1 = TaintedUtils.newTaintedString(id, op1, 'param1', 'REQUEST')


### PR DESCRIPTION
### What does this PR do?

Prevent tainting empty strings

### Motivation

Empty strings shares the same pointer. This leads to identify as tainted all empty strings when one empty string has been tainted.

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Unit tests have been updated and pass

