### PR TITLE
Fix range calculation for slice and substr with negative start indexes

### DIFF
--- a/src/api/slice.cc
+++ b/src/api/slice.cc
@@ -64,7 +64,7 @@ void slice(const FunctionCallbackInfo<Value>& args) {
         int subjectLength = Local<String>::Cast(vSubject)->Length();
         int resultLength = Local<String>::Cast(vResult)->Length();
         int sliceEnd = args.Length() > 4 ? args[4]->IntegerValue(context).FromJust() : subjectLength;
-        sliceStart = sliceStart < 0 ? subjectLength + sliceStart : sliceStart;
+        sliceStart = sliceStart < 0 ? MAX(subjectLength + sliceStart, 0) : sliceStart;
         sliceEnd = sliceEnd < 0 ? subjectLength + sliceEnd : sliceEnd;
         auto newRanges = getRangesInSlice(transaction, taintedObj, sliceStart, sliceEnd);
         if (newRanges && newRanges->Size() > 0) {

--- a/src/api/substring.cc
+++ b/src/api/substring.cc
@@ -153,7 +153,7 @@ void substr(const FunctionCallbackInfo<Value>& args) {
     }
 
     try {
-        start = (start >= 0) ? start : subjectLen + start;
+        start = (start >= 0) ? start : MAX(subjectLen + start, 0);
         length = ((start + length) >= subjectLen) ? subjectLen : start + length;
 
         auto newRanges = getRangesInSlice(transaction, taintedObj, start, length);

--- a/test/js/slice.spec.js
+++ b/test/js/slice.spec.js
@@ -115,6 +115,30 @@ describe('Slice', function () {
       result: 'b:+-a-+:z:+-z-+::+-z-+:',
       start: 6,
       end: 20
+    },
+    {
+      source: ':+-bar-+:foo:+-baz-+:',
+      result: ':+-bar-+:foo:+-b-+:',
+      start: -200,
+      end: -2
+    },
+    {
+      source: ':+-bar-+:foo:+-baz-+:',
+      result: '',
+      start: -200,
+      end: -30
+    },
+    {
+      source: ':+-bar-+:foo:+-baz-+:',
+      result: ':+-bar-+:foo:+-ba-+:',
+      start: -200,
+      end: 8
+    },
+    {
+      source: ':+-bar-+:foo:+-baz-+:',
+      result: ':+-bar-+:foo:+-baz-+:',
+      start: -200,
+      end: 200
     }
   ]
 

--- a/test/js/substr.spec.js
+++ b/test/js/substr.spec.js
@@ -135,6 +135,36 @@ const rangesTestCases = [
     source: 'foo:+-bar-+:b:+-a-+:z:+-z-+::+-z-+:',
     result: 'b:+-a-+:z:+-z-+::+-z-+:',
     start: 6
+  },
+  {
+    source: ':+-bar-+:foo:+-baz-+:',
+    result: '',
+    start: 10,
+    end: 7
+  },
+  {
+    source: ':+-bar-+:foo:+-baz-+:',
+    result: ':+-bar-+:foo:+-b-+:',
+    start: -200,
+    end: 7
+  },
+  {
+    source: ':+-bar-+:foo:+-baz-+:',
+    result: '',
+    start: 5,
+    end: -30
+  },
+  {
+    source: ':+-bar-+:foo:+-baz-+:',
+    result: '',
+    start: 5,
+    end: -3
+  },
+  {
+    source: ':+-bar-+:foo:+-baz-+:',
+    result: 'o:+-baz-+:',
+    start: 5,
+    end: 200
   }
 ]
 

--- a/test/js/substring.spec.js
+++ b/test/js/substring.spec.js
@@ -135,6 +135,36 @@ const rangesTestCases = [
     result: 'b:+-a-+:z:+-z-+::+-z-+:',
     start: 6,
     end: 20
+  },
+  {
+    source: ':+-bar-+:foo:+-baz-+:',
+    result: ':+-bar-+:foo:+-b-+:',
+    start: -200,
+    end: 7
+  },
+  {
+    source: ':+-bar-+:foo:+-baz-+:',
+    result: '',
+    start: -200,
+    end: -30
+  },
+  {
+    source: ':+-bar-+:foo:+-baz-+:',
+    result: ':+-bar-+:foo:+-baz-+:',
+    start: -200,
+    end: 200
+  },
+  {
+    source: ':+-bar-+:foo:+-baz-+:',
+    result: ':+-ar-+:foo:+-b-+:',
+    start: 7,
+    end: 1
+  },
+  {
+    source: ':+-bar-+:foo:+-baz-+:',
+    result: '',
+    start: 10,
+    end: 19
   }
 ]
 


### PR DESCRIPTION
### What does this PR do?

Fix range limits calculation when start parameters for `slice` and `substr` methods are negative and out of bounds.

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Unit tests have been updated and pass

