### PR TITLE
Taint objects

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,7 @@
                 "./src/tainted/tainted_object.cc",
                 "./src/tainted/transaction.cc",
                 "./src/tainted/string_resource.cc",
-                "./src/api/string_methods.cc",
+                "./src/api/taint_methods.cc",
                 "./src/api/concat.cc",
                 "./src/api/trim.cc",
                 "./src/api/slice.cc",

--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ try {
     newTaintedString (transactionId, original) {
       return original
     },
+    newTaintedObject (transactionId, original) {
+      return original
+    },
     addSecureMarksToTaintedString (transactionId, original) {
       return original
     },
@@ -58,6 +61,7 @@ try {
 
 const iastNativeMethods = {
   newTaintedString: addon.newTaintedString,
+  newTaintedObject: addon.newTaintedObject,
   addSecureMarksToTaintedString: addon.addSecureMarksToTaintedString,
   isTainted: addon.isTainted,
   getMetrics: addon.getMetrics,

--- a/src/api/concat.cc
+++ b/src/api/concat.cc
@@ -37,7 +37,7 @@ void TaintConcatOperator(const FunctionCallbackInfo<Value>& args) {
         return;
     }
 
-    auto transaction = GetTransaction(utils::GetLocalStringPointer(args[0]));
+    auto transaction = GetTransaction(utils::GetLocalPointer(args[0]));
     if (transaction == nullptr) {
         args.GetReturnValue().Set(args[1]);
         return;
@@ -45,7 +45,7 @@ void TaintConcatOperator(const FunctionCallbackInfo<Value>& args) {
 
     try {
         auto argsSize = args.Length();
-        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalStringPointer(args[2]));
+        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalPointer(args[2]));
         auto ranges = taintedObj ? taintedObj->getRanges() : nullptr;
         bool usingFirstParamRanges = ranges != nullptr;
 
@@ -53,7 +53,7 @@ void TaintConcatOperator(const FunctionCallbackInfo<Value>& args) {
             int offset = utils::GetCoercedLength(isolate, args[2]);
             for (int i = 3; i < argsSize; i++) {
                 auto taintedObj = transaction->FindTaintedObject(
-                        utils::GetLocalStringPointer(args[i]));
+                        utils::GetLocalPointer(args[i]));
                 auto argRanges = taintedObj ? taintedObj->getRanges() : nullptr;
                 if (argRanges != nullptr) {
                     if (ranges == nullptr) {
@@ -85,7 +85,7 @@ void TaintConcatOperator(const FunctionCallbackInfo<Value>& args) {
         }
 
         if (ranges != nullptr) {
-            auto key = utils::GetLocalStringPointer(args[1]);
+            auto key = utils::GetLocalPointer(args[1]);
             transaction->AddTainted(key, ranges, args[1]);
             args.GetReturnValue().Set(args[1]);
             return;

--- a/src/api/metrics.cc
+++ b/src/api/metrics.cc
@@ -41,7 +41,7 @@ void GetMetrics(const FunctionCallbackInfo<Value>& args) {
         return;
     }
 
-    uintptr_t transactionId = utils::GetLocalStringPointer(args[0]);
+    uintptr_t transactionId = utils::GetLocalPointer(args[0]);
     auto transaction = GetTransaction(transactionId);
     if (!transaction) {
         args.GetReturnValue().SetNull();

--- a/src/api/replace.cc
+++ b/src/api/replace.cc
@@ -27,7 +27,7 @@ using v8::Integer;
 using v8::Int32;
 
 using iast::tainted::Range;
-using iast::utils::GetLocalStringPointer;
+using iast::utils::GetLocalPointer;
 
 namespace iast {
 namespace api {
@@ -209,7 +209,7 @@ void TaintReplaceStringByStringMethod(const FunctionCallbackInfo<Value>& args) {
         return;
     }
 
-    auto transaction = GetTransaction(GetLocalStringPointer(args[0]));
+    auto transaction = GetTransaction(GetLocalPointer(args[0]));
     if (!transaction) {
         args.GetReturnValue().Set(replaceResult);
         return;
@@ -218,8 +218,8 @@ void TaintReplaceStringByStringMethod(const FunctionCallbackInfo<Value>& args) {
     try {
         MatcherArguments methodArguments = {args[1], args[2], args[3], args[4], args[5]};
 
-        auto taintedSubject = transaction->FindTaintedObject(GetLocalStringPointer(methodArguments.self));
-        auto taintedReplacer = transaction->FindTaintedObject(GetLocalStringPointer(methodArguments.replacer));
+        auto taintedSubject = transaction->FindTaintedObject(GetLocalPointer(methodArguments.self));
+        auto taintedReplacer = transaction->FindTaintedObject(GetLocalPointer(methodArguments.replacer));
         auto subjectRanges = (taintedSubject) ? taintedSubject->getRanges() : nullptr;
         auto replacerRanges = (taintedReplacer) ? taintedReplacer->getRanges() : nullptr;
 
@@ -236,7 +236,7 @@ void TaintReplaceStringByStringMethod(const FunctionCallbackInfo<Value>& args) {
             if (resultLength == 1) {
                 replaceResult = tainted::NewExternalString(isolate, replaceResult);
             }
-            auto key = GetLocalStringPointer(replaceResult);
+            auto key = GetLocalPointer(replaceResult);
             transaction->AddTainted(key, newRanges, replaceResult);
         }
     } catch (const std::bad_alloc& err) {
@@ -257,7 +257,7 @@ void TaintReplaceStringByStringUsingRegexMethod(const FunctionCallbackInfo<Value
         return;
     }
 
-    auto transaction = GetTransaction(GetLocalStringPointer(args[0]));
+    auto transaction = GetTransaction(GetLocalPointer(args[0]));
     if (!transaction) {
         args.GetReturnValue().Set(replaceResult);
         return;
@@ -266,8 +266,8 @@ void TaintReplaceStringByStringUsingRegexMethod(const FunctionCallbackInfo<Value
     try {
         MatcherArguments methodArguments = {args[1], args[2], args[3], args[4], args[5]};
 
-        auto taintedSubject = transaction->FindTaintedObject(GetLocalStringPointer(methodArguments.self));
-        auto taintedReplacer = transaction->FindTaintedObject(GetLocalStringPointer(methodArguments.replacer));
+        auto taintedSubject = transaction->FindTaintedObject(GetLocalPointer(methodArguments.self));
+        auto taintedReplacer = transaction->FindTaintedObject(GetLocalPointer(methodArguments.replacer));
         auto subjectRanges = (taintedSubject) ? taintedSubject->getRanges() : nullptr;
         auto replacerRanges = (taintedReplacer) ? taintedReplacer->getRanges() : nullptr;
 
@@ -288,7 +288,7 @@ void TaintReplaceStringByStringUsingRegexMethod(const FunctionCallbackInfo<Value
             if (resultLength == 1) {
                 replaceResult = tainted::NewExternalString(args.GetIsolate(), replaceResult);
             }
-            auto key = utils::GetLocalStringPointer(replaceResult);
+            auto key = utils::GetLocalPointer(replaceResult);
             transaction->AddTainted(key, newRanges, replaceResult);
         }
     } catch (const std::bad_alloc& err) {

--- a/src/api/slice.cc
+++ b/src/api/slice.cc
@@ -21,7 +21,7 @@ using v8::Isolate;
 using v8::String;
 using v8::NewStringType;
 using v8::Exception;
-using utils::GetLocalStringPointer;
+using utils::GetLocalPointer;
 using utils::getRangesInSlice;
 
 void slice(const FunctionCallbackInfo<Value>& args) {
@@ -47,13 +47,13 @@ void slice(const FunctionCallbackInfo<Value>& args) {
 
     int sliceStart = args[3]->IntegerValue(context).FromJust();
 
-    Transaction* transaction = GetTransaction(GetLocalStringPointer(args[0]));
+    Transaction* transaction = GetTransaction(GetLocalPointer(args[0]));
     if (transaction == nullptr) {
         args.GetReturnValue().Set(vResult);
         return;
     }
 
-    auto taintedObj = transaction->FindTaintedObject(GetLocalStringPointer(vSubject));
+    auto taintedObj = transaction->FindTaintedObject(GetLocalPointer(vSubject));
 
     if (!taintedObj) {
         args.GetReturnValue().Set(vResult);
@@ -71,7 +71,7 @@ void slice(const FunctionCallbackInfo<Value>& args) {
             if (resultLength == 1) {
                 vResult = tainted::NewExternalString(isolate, args[1]);
             }
-            transaction->AddTainted(GetLocalStringPointer(vResult), newRanges, vResult);
+            transaction->AddTainted(GetLocalPointer(vResult), newRanges, vResult);
         }
     } catch (const std::bad_alloc& err) {
     } catch (const container::QueuedPoolBadAlloc& err) {

--- a/src/api/string_methods.cc
+++ b/src/api/string_methods.cc
@@ -85,14 +85,14 @@ void NewTaintedString(const FunctionCallbackInfo<Value>& args) {
 
     args.GetReturnValue().Set(parameterValue);
 
-    uintptr_t transactionId = utils::GetLocalStringPointer(transactionIdArgument);
+    uintptr_t transactionId = utils::GetLocalPointer(transactionIdArgument);
 
     try {
         auto transaction = NewTransaction(transactionId);
         if (transaction == nullptr) {
             return;
         }
-        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalStringPointer(parameterValue));
+        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalPointer(parameterValue));
         if (taintedObj) {
             // Object already exist, nothing to do
             return;
@@ -106,8 +106,8 @@ void NewTaintedString(const FunctionCallbackInfo<Value>& args) {
                 inputInfo, 0);
         auto ranges = transaction->GetSharedVectorRange();
         ranges->PushBack(range);
-        auto stringPointer = utils::GetLocalStringPointer(parameterValue);
-        transaction->AddTainted(stringPointer, ranges, parameterValue);
+        auto valuePointer = utils::GetLocalPointer(parameterValue);
+        transaction->AddTainted(valuePointer, ranges, parameterValue);
     } catch (const std::bad_alloc& err) {
         // TODO(julio): log exception?
     } catch (const container::QueuedPoolBadAlloc& err) {
@@ -153,13 +153,13 @@ void AddSecureMarksToTaintedString(const FunctionCallbackInfo<Value>& args) {
         return;
     }
 
-    uintptr_t transactionId = utils::GetLocalStringPointer(transactionIdArgument);
+    uintptr_t transactionId = utils::GetLocalPointer(transactionIdArgument);
 
     auto transaction = GetTransaction(transactionId);
     if (transaction == nullptr) {
         return;
     }
-    auto taintedObj = transaction->FindTaintedObject(utils::GetLocalStringPointer(taintedString));
+    auto taintedObj = transaction->FindTaintedObject(utils::GetLocalPointer(taintedString));
     if (!taintedObj) {
         // It is not a tainted object, do nothing
         return;
@@ -176,7 +176,7 @@ void AddSecureMarksToTaintedString(const FunctionCallbackInfo<Value>& args) {
             auto oSecureMarks = oRange->secureMarks;
             newRanges->PushBack(transaction->GetRange(start, end, oRange->inputInfo, oSecureMarks | secureMarks));
         }
-        transaction->AddTainted(utils::GetLocalStringPointer(taintedString), newRanges, taintedString);
+        transaction->AddTainted(utils::GetLocalPointer(taintedString), newRanges, taintedString);
         args.GetReturnValue().Set(taintedString);
     } catch (const std::bad_alloc& err) {
     } catch (const container::QueuedPoolBadAlloc& err) {
@@ -194,14 +194,14 @@ void IsTainted(const FunctionCallbackInfo<Value>& args) {
         return;
     }
 
-    uintptr_t transactionId = utils::GetLocalStringPointer(args[0]);
+    uintptr_t transactionId = utils::GetLocalPointer(args[0]);
     auto transaction = GetTransaction(transactionId);
     if (!transaction) {
         args.GetReturnValue().Set(false);
         return;
     }
     for (auto i = 1; i < argsLength; i++) {
-        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalStringPointer(args[i]));
+        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalPointer(args[i]));
         if (taintedObj && taintedObj->getRanges()) {
             args.GetReturnValue().Set(true);
             return;
@@ -220,10 +220,10 @@ void GetRanges(const FunctionCallbackInfo<Value>& args) {
                 NewStringType::kNormal).ToLocalChecked()));
         return;
     }
-    uintptr_t transactionId = utils::GetLocalStringPointer(args[0]);
+    uintptr_t transactionId = utils::GetLocalPointer(args[0]);
     auto transaction = GetTransaction(transactionId);
     if (transaction != nullptr) {
-        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalStringPointer(args[1]));
+        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalPointer(args[1]));
         auto ranges = taintedObj ? taintedObj->getRanges() : nullptr;
         if (ranges != nullptr) {
             auto currentContext = isolate->GetCurrentContext();
@@ -251,7 +251,7 @@ void DeleteTransaction(const FunctionCallbackInfo<Value>& args) {
         return;
     }
 
-    auto transactionId = utils::GetLocalStringPointer(args[0]);
+    auto transactionId = utils::GetLocalPointer(args[0]);
     RemoveTransaction(transactionId);
 }
 
@@ -273,6 +273,65 @@ void SetMaxTransactions(const FunctionCallbackInfo<Value>& args) {
     iast::SetMaxTransactions(args[0]->IntegerValue(isolate->GetCurrentContext()).FromJust());
 }
 
+void NewTaintedObject(const FunctionCallbackInfo<Value>& args) {
+    auto isolate = args.GetIsolate();
+    if (args.Length() < 4) {
+        isolate->ThrowException(v8::Exception::TypeError(
+                        v8::String::NewFromUtf8(isolate,
+                        "Wrong number of arguments",
+                        v8::NewStringType::kNormal).ToLocalChecked()));
+        return;
+    }
+
+    if (!(args[0]->IsString()) || !Local<String>::Cast(args[0])->Length()) {
+        args.GetReturnValue().Set(args[1]);
+        return;
+    }
+
+    if ((args[1]->IsString())) {
+        return NewTaintedString(args);
+    }
+
+    auto transactionIdArgument = args[0];
+    auto parameterValue = args[1];
+    auto parameterName = args[2];
+    auto type = args[3];
+
+    args.GetReturnValue().Set(parameterValue);
+
+    uintptr_t transactionId = utils::GetLocalPointer(transactionIdArgument);
+
+    try {
+        auto transaction = NewTransaction(transactionId);
+        if (transaction == nullptr) {
+            return;
+        }
+        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalPointer(parameterValue));
+        if (taintedObj) {
+            // Object already exist, nothing to do
+            return;
+        }
+
+        InputInfo* inputInfo = transaction->createNewInputInfo(
+                    parameterName, parameterValue, type);
+
+        auto range = transaction->GetRange(0,
+            utils::GetLength(args.GetIsolate(), parameterValue),
+            inputInfo, 0);
+        auto ranges = transaction->GetSharedVectorRange();
+        ranges->PushBack(range);
+
+        auto valuePointer = utils::GetLocalPointer(parameterValue);
+        transaction->AddTainted(valuePointer, ranges, parameterValue);
+    } catch (const std::bad_alloc& err) {
+        // TODO(julio): log exception?
+    } catch (const container::QueuedPoolBadAlloc& err) {
+        // TODO(julio): log exception?
+    } catch (const container::PoolBadAlloc& err) {
+        // TODO(julio): log exception?
+    }
+}
+
 void StringMethods::Init(Local<Object> exports) {
     NODE_SET_METHOD(exports, "createTransaction", CreateTransaction);
     NODE_SET_METHOD(exports, "newTaintedString", NewTaintedString);
@@ -281,6 +340,7 @@ void StringMethods::Init(Local<Object> exports) {
     NODE_SET_METHOD(exports, "getRanges", GetRanges);
     NODE_SET_METHOD(exports, "removeTransaction", DeleteTransaction);
     NODE_SET_METHOD(exports, "setMaxTransactions", SetMaxTransactions);
+    NODE_SET_METHOD(exports, "newTaintedObject", NewTaintedObject);
 }
 }  // namespace api
 }  // namespace iast

--- a/src/api/substring.cc
+++ b/src/api/substring.cc
@@ -30,7 +30,7 @@ using v8::Object;
 using v8::String;
 using v8::Value;
 
-using iast::utils::GetLocalStringPointer;
+using iast::utils::GetLocalPointer;
 using iast::utils::getRangesInSlice;
 
 namespace iast {
@@ -68,7 +68,7 @@ void substring(const FunctionCallbackInfo<Value>& args) {
         args.GetReturnValue().Set(result);
         return;
     }
-    auto transaction = GetTransaction(GetLocalStringPointer(args[0]));
+    auto transaction = GetTransaction(GetLocalPointer(args[0]));
     if (transaction == nullptr) {
         args.GetReturnValue().Set(result);
         return;
@@ -79,7 +79,7 @@ void substring(const FunctionCallbackInfo<Value>& args) {
         return;
     }
 
-    auto taintedObj = transaction->FindTaintedObject(GetLocalStringPointer(subject));
+    auto taintedObj = transaction->FindTaintedObject(GetLocalPointer(subject));
     if (!taintedObj) {
         args.GetReturnValue().Set(result);
         return;
@@ -92,7 +92,7 @@ void substring(const FunctionCallbackInfo<Value>& args) {
             if (resultLen == 1) {
                 result = tainted::NewExternalString(isolate, args[1]);
             }
-            transaction->AddTainted(GetLocalStringPointer(result), newRanges, result);
+            transaction->AddTainted(GetLocalPointer(result), newRanges, result);
         }
     } catch (const std::bad_alloc& err) {
     } catch (const container::QueuedPoolBadAlloc& err) {
@@ -135,7 +135,7 @@ void substr(const FunctionCallbackInfo<Value>& args) {
         length = TO_INTEGER_VALUE(args[4], context);
     }
 
-    auto transaction = GetTransaction(GetLocalStringPointer(args[0]));
+    auto transaction = GetTransaction(GetLocalPointer(args[0]));
     if (transaction == nullptr) {
         args.GetReturnValue().Set(result);
         return;
@@ -146,7 +146,7 @@ void substr(const FunctionCallbackInfo<Value>& args) {
         return;
     }
 
-    auto taintedObj = transaction->FindTaintedObject(GetLocalStringPointer(subject));
+    auto taintedObj = transaction->FindTaintedObject(GetLocalPointer(subject));
     if (!taintedObj) {
         args.GetReturnValue().Set(result);
         return;
@@ -161,7 +161,7 @@ void substr(const FunctionCallbackInfo<Value>& args) {
             if (resultLen == 1) {
                 result = tainted::NewExternalString(isolate, args[1]);
             }
-            transaction->AddTainted(GetLocalStringPointer(result), newRanges, result);
+            transaction->AddTainted(GetLocalPointer(result), newRanges, result);
         }
     } catch (const std::bad_alloc& err) {
     } catch (const container::QueuedPoolBadAlloc& err) {

--- a/src/api/taint_methods.cc
+++ b/src/api/taint_methods.cc
@@ -12,7 +12,7 @@
 #include <iterator>
 #include <memory>
 
-#include "string_methods.h"
+#include "taint_methods.h"
 #include "../tainted/string_resource.h"
 #include "../tainted/input_info.h"
 #include "../tainted/tainted_object.h"
@@ -183,6 +183,7 @@ void AddSecureMarksToTaintedString(const FunctionCallbackInfo<Value>& args) {
     } catch (const container::PoolBadAlloc& err) {
     }
 }
+
 void IsTainted(const FunctionCallbackInfo<Value>& args) {
     auto argsLength = args.Length();
     if (argsLength < 2) {
@@ -332,7 +333,7 @@ void NewTaintedObject(const FunctionCallbackInfo<Value>& args) {
     }
 }
 
-void StringMethods::Init(Local<Object> exports) {
+void TaintMethods::Init(Local<Object> exports) {
     NODE_SET_METHOD(exports, "createTransaction", CreateTransaction);
     NODE_SET_METHOD(exports, "newTaintedString", NewTaintedString);
     NODE_SET_METHOD(exports, "addSecureMarksToTaintedString", AddSecureMarksToTaintedString);

--- a/src/api/taint_methods.cc
+++ b/src/api/taint_methods.cc
@@ -290,7 +290,8 @@ void NewTaintedObject(const FunctionCallbackInfo<Value>& args) {
     }
 
     if ((args[1]->IsString())) {
-        return NewTaintedString(args);
+        args.GetReturnValue().Set(args[1]);
+        return;
     }
 
     auto transactionIdArgument = args[0];

--- a/src/api/taint_methods.h
+++ b/src/api/taint_methods.h
@@ -2,8 +2,8 @@
 * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 **/
-#ifndef SRC_API_STRING_METHODS_H_
-#define SRC_API_STRING_METHODS_H_
+#ifndef SRC_API_TAINT_METHODS_H_
+#define SRC_API_TAINT_METHODS_H_
 
 #include <node.h>
 
@@ -12,15 +12,15 @@ namespace api {
 using v8::Local;
 using v8::Object;
 
-class StringMethods {
+class TaintMethods {
  public:
     static void Init(Local<Object> exports);
 
  private:
-    StringMethods();
-    ~StringMethods();
+    TaintMethods();
+    ~TaintMethods();
 };
 }    // namespace api
 }    // namespace iast
 
-#endif  // SRC_API_STRING_METHODS_H_
+#endif  // SRC_API_TAINT_METHODS_H_

--- a/src/api/trim.cc
+++ b/src/api/trim.cc
@@ -42,14 +42,14 @@ void TaintTrimOperator(const FunctionCallbackInfo<Value>& args) {
         return;
     }
 
-    auto transaction = GetTransaction(utils::GetLocalStringPointer(args[0]));
+    auto transaction = GetTransaction(utils::GetLocalPointer(args[0]));
     if (transaction == nullptr) {
         args.GetReturnValue().Set(args[1]);
         return;
     }
 
     try {
-        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalStringPointer(args[2]));
+        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalPointer(args[2]));
         auto ranges = taintedObj ? taintedObj->getRanges() : nullptr;
         if (ranges == nullptr) {
             args.GetReturnValue().Set(args[1]);
@@ -95,7 +95,7 @@ void TaintTrimOperator(const FunctionCallbackInfo<Value>& args) {
             if (resultLength == 1) {
                 res = tainted::NewExternalString(isolate, res);
             }
-            auto key = utils::GetLocalStringPointer(res);
+            auto key = utils::GetLocalPointer(res);
             transaction->AddTainted(key, resultRanges, res);
             args.GetReturnValue().Set(res);
             return;
@@ -122,14 +122,14 @@ void TaintTrimEndOperator(const FunctionCallbackInfo<Value>& args) {
         return;
     }
 
-    auto transaction = GetTransaction(utils::GetLocalStringPointer(args[0]));
+    auto transaction = GetTransaction(utils::GetLocalPointer(args[0]));
     if (transaction == nullptr) {
         args.GetReturnValue().Set(args[1]);
         return;
     }
 
     try {
-        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalStringPointer(args[2]));
+        auto taintedObj = transaction->FindTaintedObject(utils::GetLocalPointer(args[2]));
         auto ranges = taintedObj ? taintedObj->getRanges() : nullptr;
         if (ranges == nullptr) {
             args.GetReturnValue().Set(args[1]);
@@ -160,7 +160,7 @@ void TaintTrimEndOperator(const FunctionCallbackInfo<Value>& args) {
             if (resultLength == 1) {
                 res = tainted::NewExternalString(isolate, res);
             }
-            auto key = utils::GetLocalStringPointer(res);
+            auto key = utils::GetLocalPointer(res);
             transaction->AddTainted(key, resultRanges, res);
             args.GetReturnValue().Set(res);
             return;

--- a/src/iast.cc
+++ b/src/iast.cc
@@ -9,7 +9,7 @@
 #include "gc/gc.h"
 #include "container/singleton.h"
 #include "transaction_manager.h"
-#include "api/string_methods.h"
+#include "api/taint_methods.h"
 #include "tainted/transaction.h"
 #include "api/concat.h"
 #include "api/trim.h"
@@ -44,7 +44,7 @@ void SetMaxTransactions(size_t maxItems) {
 }
 
 void Init(v8::Local<v8::Object> exports) {
-    api::StringMethods::Init(exports);
+    api::TaintMethods::Init(exports);
     api::ConcatOperations::Init(exports);
     api::TrimOperations::Init(exports);
     api::SliceOperations::Init(exports);

--- a/src/tainted/tainted_object.h
+++ b/src/tainted/tainted_object.h
@@ -33,7 +33,7 @@ class TaintedObject: public iast::WeakObjIface<TaintedObject*> {
     bool IsEmpty() { return target.IsEmpty(); }
 
     weak_key_t Get() {
-        return utils::GetLocalStringPointer(target.Get(v8::Isolate::GetCurrent()));
+        return utils::GetLocalPointer(target.Get(v8::Isolate::GetCurrent()));
     }
 
     void Reset(v8::Local<v8::Value> v) {

--- a/src/tainted/transaction.h
+++ b/src/tainted/transaction.h
@@ -61,11 +61,11 @@ class Transaction {
         _taintedMap.Rehash();
     }
 
-    void AddTainted(weak_key_t key, SharedRanges* ranges, v8::Local<v8::Value> jsString) {
+    void AddTainted(weak_key_t key, SharedRanges* ranges, v8::Local<v8::Value> jsValue) {
         // TODO(julio): trigger exception from the pool rather than a nullptr
         auto tainted = _taintedObjPool.Pop(key,
                 ranges,
-                jsString);
+                jsValue);
         if (tainted) {
             _taintedMap.Insert(key, tainted);
         }

--- a/src/utils/string_utils.h
+++ b/src/utils/string_utils.h
@@ -47,16 +47,20 @@ inline int GetLength(v8::Isolate* isolate, v8::Local<v8::Value> val) {
         return v8::String::Cast(*val)->Length();
     } else if (val->IsStringObject()) {
         return v8::StringObject::Cast(*val)->ValueOf()->Length();
+    } else if (val->IsArrayBuffer()) {
+        return v8::ArrayBuffer::Cast(*val)->ByteLength();
+    } else if (val->IsArrayBufferView()) {
+        return v8::ArrayBufferView::Cast(*val)->ByteLength();
     } else {
         if (val->IsUndefined()) {
             return 0;
         } else if (val->IsNull()) {
             return 0;
         } else {
-            return v8::String::kMaxLength;
-            // auto context = isolate->GetCurrentContext();
-            // auto firstLocalString =  val->ToString(context).ToLocalChecked();
-            // return firstLocalString->Length();
+            // TODO: this case is when we try to taint unknown objects. We could return v8::String::kMaxLength to avoid calling val->ToString
+            auto context = isolate->GetCurrentContext();
+            auto firstLocalString =  val->ToString(context).ToLocalChecked();
+            return firstLocalString->Length();
         }
     }
 }

--- a/src/utils/string_utils.h
+++ b/src/utils/string_utils.h
@@ -57,7 +57,8 @@ inline int GetLength(v8::Isolate* isolate, v8::Local<v8::Value> val) {
         } else if (val->IsNull()) {
             return 0;
         } else {
-            // TODO: this case is when we try to taint unknown objects. We could return v8::String::kMaxLength to avoid calling val->ToString
+            // TODO(julio_igor): this case is when we try to taint unknown objects. 
+            // Could it return v8::String::kMaxLength to avoid calling val->ToString?
             auto context = isolate->GetCurrentContext();
             auto firstLocalString =  val->ToString(context).ToLocalChecked();
             return firstLocalString->Length();

--- a/src/utils/string_utils.h
+++ b/src/utils/string_utils.h
@@ -57,7 +57,7 @@ inline int GetLength(v8::Isolate* isolate, v8::Local<v8::Value> val) {
         } else if (val->IsNull()) {
             return 0;
         } else {
-            // TODO(julio_igor): this case is when we try to taint unknown objects. 
+            // TODO(julio_igor): this case is when we try to taint unknown objects.
             // Could it return v8::String::kMaxLength to avoid calling val->ToString?
             auto context = isolate->GetCurrentContext();
             auto firstLocalString =  val->ToString(context).ToLocalChecked();

--- a/src/utils/string_utils.h
+++ b/src/utils/string_utils.h
@@ -15,7 +15,7 @@ namespace utils {
 const int COERCED_NULL_LENGTH = 4;
 const int COERCED_UNDEFINED_LENGTH = 9;
 
-inline uintptr_t GetLocalStringPointer(v8::Local<v8::Value> val) {
+inline uintptr_t GetLocalPointer(v8::Local<v8::Value> val) {
     return *reinterpret_cast<uintptr_t*>(*val);
 }
 
@@ -45,15 +45,18 @@ inline std::string GetCString(v8::Isolate* isolate, v8::Local<v8::Value> val) {
 inline int GetLength(v8::Isolate* isolate, v8::Local<v8::Value> val) {
     if (val->IsString()) {
         return v8::String::Cast(*val)->Length();
+    } else if (val->IsStringObject()) {
+        return v8::StringObject::Cast(*val)->ValueOf()->Length();
     } else {
         if (val->IsUndefined()) {
             return 0;
         } else if (val->IsNull()) {
             return 0;
         } else {
-            auto context = isolate->GetCurrentContext();
-            auto firstLocalString =  val->ToString(context).ToLocalChecked();
-            return firstLocalString->Length();
+            return v8::String::kMaxLength;
+            // auto context = isolate->GetCurrentContext();
+            // auto firstLocalString =  val->ToString(context).ToLocalChecked();
+            // return firstLocalString->Length();
         }
     }
 }

--- a/test/js/new_tainted_object.spec.js
+++ b/test/js/new_tainted_object.spec.js
@@ -36,28 +36,13 @@ describe('Taint objects', function () {
     assert.strictEqual(ret, value, 'Unexpected value')
   })
 
-  it('Taint string through newTaintedObject method', function () {
+  it('Taint string through newTaintedObject method should not taint string', function () {
     const value = 'test'
     const ret = TaintedUtils.newTaintedObject(id, value, 'param', 'REQUEST')
     assert.strictEqual(ret, value, 'Unexpected value')
 
     // a new string is created when value length < 10
-    assert.strictEqual(true, TaintedUtils.isTainted(id, ret), 'value should be tainted')
-
-    const ranges = TaintedUtils.getRanges(id, ret)
-
-    assert.strictEqual(ranges.length, 1, 'Unexpected ranges length')
-
-    assert.deepEqual(ranges[0], {
-      start: 0,
-      end: ret.length,
-      iinfo: {
-        parameterName: 'param',
-        parameterValue: ret,
-        type: 'REQUEST'
-      },
-      secureMarks: 0
-    })
+    assert.strictEqual(false, TaintedUtils.isTainted(id, ret), 'value should not be tainted')
   })
 
   it('Check tainted object', function () {

--- a/test/js/new_tainted_object.spec.js
+++ b/test/js/new_tainted_object.spec.js
@@ -83,7 +83,7 @@ describe('Taint objects', function () {
 
     assert.deepEqual(ranges[0], {
       start: 0,
-      end: 536870888, // v8 string max size = 4 ? (1 << 28) - 16 : (1 << 29) - 24;
+      end: 4,
       iinfo: {
         parameterName: 'param',
         parameterValue: value,

--- a/test/js/new_tainted_object.spec.js
+++ b/test/js/new_tainted_object.spec.js
@@ -1,0 +1,95 @@
+/**
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+* This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+**/
+const { TaintedUtils } = require('./util')
+const assert = require('assert')
+
+describe('Taint objects', function () {
+  const value = Buffer.from('test')
+  const id = TaintedUtils.createTransaction('1')
+
+  before(() => {
+    TaintedUtils.setMaxTransactions(1)
+  })
+
+  afterEach(function () {
+    TaintedUtils.removeTransaction(id)
+  })
+
+  after(() => {
+    TaintedUtils.setMaxTransactions(2)
+  })
+
+  it('Taint buffer with undefined transaction', function () {
+    const ret = TaintedUtils.newTaintedObject(undefined, value, 'param', 'REQUEST')
+    assert.strictEqual(ret, value, 'Unexpected value')
+  })
+
+  it('Taint buffer with empty transaction', function () {
+    const ret = TaintedUtils.newTaintedObject('', value, 'param', 'REQUEST')
+    assert.strictEqual(ret, value, 'Unexpected value')
+  })
+
+  it('Taint buffer with valid transaction', function () {
+    const ret = TaintedUtils.newTaintedObject(id, value, 'param', 'REQUEST')
+    assert.strictEqual(ret, value, 'Unexpected value')
+  })
+
+  it('Taint string through newTaintedObject method', function () {
+    const value = 'test'
+    const ret = TaintedUtils.newTaintedObject(id, value, 'param', 'REQUEST')
+    assert.strictEqual(ret, value, 'Unexpected value')
+
+    // a new string is created when value length < 10
+    assert.strictEqual(true, TaintedUtils.isTainted(id, ret), 'value should be tainted')
+
+    const ranges = TaintedUtils.getRanges(id, ret)
+
+    assert.strictEqual(ranges.length, 1, 'Unexpected ranges length')
+
+    assert.deepEqual(ranges[0], {
+      start: 0,
+      end: ret.length,
+      iinfo: {
+        parameterName: 'param',
+        parameterValue: ret,
+        type: 'REQUEST'
+      },
+      secureMarks: 0
+    })
+  })
+
+  it('Check tainted object', function () {
+    const taintedValue = TaintedUtils.newTaintedObject(id, value, 'param', 'REQUEST')
+    const ret = TaintedUtils.isTainted(id, taintedValue)
+    assert.strictEqual(ret, true, 'Unexpected value')
+  })
+
+  it('Check tainted String object', function () {
+    const taintedValue = TaintedUtils.newTaintedObject(id, new String('test'), 'param', 'REQUEST')
+    const ret = TaintedUtils.isTainted(id, taintedValue)
+    assert.strictEqual(ret, true, 'Unexpected value')
+  })
+
+  it('Check tainted object ranges', function () {
+    const taintedValue = TaintedUtils.newTaintedObject(id, value, 'param', 'REQUEST')
+    const ret = TaintedUtils.isTainted(id, taintedValue)
+    assert.strictEqual(ret, true, 'Unexpected value')
+
+    const ranges = TaintedUtils.getRanges(id, value)
+
+    assert.strictEqual(ranges.length, 1, 'Unexpected value')
+
+    assert.deepEqual(ranges[0], {
+      start: 0,
+      end: 536870888, // v8 string max size = 4 ? (1 << 28) - 16 : (1 << 29) - 24;
+      iinfo: {
+        parameterName: 'param',
+        parameterValue: value,
+        type: 'REQUEST'
+      },
+      secureMarks: 0
+    })
+  })
+})

--- a/test/js/new_tainted_object.spec.js
+++ b/test/js/new_tainted_object.spec.js
@@ -67,6 +67,7 @@ describe('Taint objects', function () {
   })
 
   it('Check tainted String object', function () {
+    // eslint-disable-next-line no-new-wrappers
     const taintedValue = TaintedUtils.newTaintedObject(id, new String('test'), 'param', 'REQUEST')
     const ret = TaintedUtils.isTainted(id, taintedValue)
     assert.strictEqual(ret, true, 'Unexpected value')


### PR DESCRIPTION
### What does this PR do?

Exposes the `newTaintedObject` method to taint objects.


### Motivation

Allow IAST to taint Buffer objects used for example by kafka consumers

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass

