### PR TITLE
Fix NewExternalString length

### DIFF
--- a/src/tainted/string_resource.cc
+++ b/src/tainted/string_resource.cc
@@ -24,7 +24,8 @@ void StringResource::CopyCharArrToUint16Arr(const char* charArr, uint16_t* resul
 v8::Local<v8::String> NewExternalString(v8::Isolate* isolate, v8::Local<v8::Value> obj) {
     v8::String::Utf8Value originalStringValue(isolate, obj);
     const char* originalCharArr = *originalStringValue;
-    auto resource = new StringResource(originalCharArr, originalStringValue.length());
+    int length = v8::Local<v8::String>::Cast(obj)->Length();
+    auto resource = new StringResource(originalCharArr, length);
     return v8::String::NewExternalTwoByte(isolate, resource).ToLocalChecked();
 }
 }  // namespace tainted

--- a/test/js/new_tainted_string.spec.js
+++ b/test/js/new_tainted_string.spec.js
@@ -167,4 +167,16 @@ describe('Taint strings', function () {
     assert.strictEqual(true, TaintedUtils.isTainted(id, taintedOneChar), 'Must be tainted')
     assert.strictEqual(false, TaintedUtils.isTainted(id, oneChar), 'Can not be tainted')
   })
+
+  describe('Taint special one char strings', function () {
+    const specialOneCharStrings = ['佫', 'ü', 'ô', 'é', 'à']
+
+    specialOneCharStrings.forEach((testStr) => {
+      it(`Taint ${testStr}`, function () {
+        const taintedStr = TaintedUtils.newTaintedString(id, testStr, 'param', 'request')
+        assert.strictEqual(true, TaintedUtils.isTainted(id, taintedStr), 'Must be tainted')
+        assert.strictEqual(testStr, taintedStr, 'Strings must be equal')
+      })
+    })
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Assigns the v8 string length to new external strings created when tainting one char strings.

Previously, the assigned length for these strings were the c++ char[] length, which lead to unexpected results.

### Motivation

The result of tainting strings like `佫` result in a string with two additional null bytes, since the char[] length is 3.

### Additional Notes

When tainting a one char string, a new External String is made to avoid v8 string cache.

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Unit tests have been updated and pass

