### PR TITLE
Release 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datadog/native-iast-taint-tracking",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@datadog/native-iast-taint-tracking",
-      "version": "1.7.0",
+      "version": "2.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@datadog/native-iast-taint-tracking",
   "home": "https://github.com/DataDog/dd-native-iast-taint-tracking-js/blob/main/README.md",
   "repository": "git@github.com:DataDog/dd-native-iast-taint-tracking-js.git",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "description": "Datadog IAST tant tracking support for NodeJS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### What does this PR do?

Release 2.0.0

### Motivation

- Dropping support for Node 12
- Adding new string propagation methods

### Additional Notes

Major release due to support dropping.

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Unit tests have been updated and pass

