### PR TITLE
Add support for node 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     needs: ['cpp-lint', 'js-lint']
     strategy:
       matrix:
-        version: [14, 15, 16, 17, 18, 19, 20, 21]
+        version: [14, 15, 16, 17, 18, 19, 20, 21, 22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -28,7 +28,7 @@ jobs:
     needs: ['cpp-lint', 'js-lint']
     strategy:
       matrix:
-        version: [14, 15, 16, 17, 18, 19, 20, 21]
+        version: [14, 15, 16, 17, 18, 19, 20, 21, 22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -176,7 +176,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '19'
+          node-version: '20'
       - run: npm i --ignore-scripts
       - run: npm run lint
 
@@ -186,7 +186,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '19'
+          node-version: '20'
       - run: npm i --ignore-scripts
       - run: node scripts/check_licenses.js
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
       - run: npm pack
       - uses: codex-team/action-nodejs-package-info@v1
         id: package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,11 +112,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
       - run: npm pack
       - uses: codex-team/action-nodejs-package-info@v1
         id: package
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}
           path: '*.tgz'
@@ -148,7 +148,7 @@ jobs:
       - run: npm install node-gyp
       - uses: codex-team/action-nodejs-package-info@v1
         id: package
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}
       - run: npm i --verbose datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}.tgz

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -134,6 +134,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
       - run: npm pack
       - uses: codex-team/action-nodejs-package-info@v1
         id: package

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,7 +40,7 @@ jobs:
 
   build:
     needs: ['cpp-lint', 'js-lint']
-    uses: Datadog/action-prebuildify/.github/workflows/build.yml@main
+    uses: Datadog/action-prebuildify/.github/workflows/build.yml@ugaitz/support-node22
     with:
       cache: false
       napi: false

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,7 @@ jobs:
     needs: ['cpp-lint', 'js-lint']
     strategy:
       matrix:
-        version: [14, 16, 18, 19, 20, 21]
+        version: [14, 16, 18, 19, 20, 21, 22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
     needs: ['cpp-lint', 'js-lint']
     strategy:
       matrix:
-        version: [14, 16, 18, 19, 20, 21]
+        version: [14, 16, 18, 19, 20, 21, 22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '19'
+          node-version: '20'
       - run: npm i --ignore-scripts
       - run: npm run lint
 
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '19'
+          node-version: '20'
       - run: npm i --ignore-scripts
       - run: node scripts/check_licenses.js
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,7 +40,7 @@ jobs:
 
   build:
     needs: ['cpp-lint', 'js-lint']
-    uses: Datadog/action-prebuildify/.github/workflows/build.yml@ugaitz/support-node22
+    uses: Datadog/action-prebuildify/.github/workflows/build.yml@main
     with:
       cache: false
       napi: false

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -133,11 +133,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
       - run: npm pack
       - uses: codex-team/action-nodejs-package-info@v1
         id: package
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}
           path: '*.tgz'
@@ -169,7 +169,7 @@ jobs:
       - run: npm install node-gyp
       - uses: codex-team/action-nodejs-package-info@v1
         id: package
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}
       - run: npm i --verbose datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}.tgz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
       - run: npm pack
       - uses: codex-team/action-nodejs-package-info@v1
         id: package
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}.tgz
           path: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}.tgz
@@ -38,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: codex-team/action-nodejs-package-info@v1.1
         id: package
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}.tgz
       - uses: actions/create-release@v1
@@ -73,7 +75,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: codex-team/action-nodejs-package-info@v1.1
         id: package
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: datadog-native-iast-taint-tracking-${{ steps.package.outputs.version }}.tgz
       - uses: actions/setup-node@v3


### PR DESCRIPTION
### What does this PR do?

- Adds support for node 22
- Updates `download-artifact` and `upload-artifact` to v4 because actions-prebuildify is using it.


