### PR TITLE
Remove node 14 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     needs: ['cpp-lint', 'js-lint']
     strategy:
       matrix:
-        version: [14, 15, 16, 17, 18, 19, 20, 21, 22]
+        version: [15, 16, 17, 18, 19, 20, 21, 22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -28,7 +28,7 @@ jobs:
     needs: ['cpp-lint', 'js-lint']
     strategy:
       matrix:
-        version: [14, 15, 16, 17, 18, 19, 20, 21, 22]
+        version: [15, 16, 17, 18, 19, 20, 21, 22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -52,7 +52,7 @@ jobs:
       prebuild: 'node scripts/prebuild'
       skip: 'linux-arm linux-ia32'
       target-name: 'iastnativemethods'
-      min-node-version: 14
+      min-node-version: 16
 
   cpp-test-libc:
     needs: ['build']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     needs: ['cpp-lint', 'js-lint']
     strategy:
       matrix:
-        version: [15, 16, 17, 18, 19, 20, 21, 22]
+        version: [16, 17, 18, 19, 20, 21, 22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -28,7 +28,7 @@ jobs:
     needs: ['cpp-lint', 'js-lint']
     strategy:
       matrix:
-        version: [15, 16, 17, 18, 19, 20, 21, 22]
+        version: [16, 17, 18, 19, 20, 21, 22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v4
         with:
-          merge-multiple: true
+          name: prebuilds
       - run: npm pack
       - uses: codex-team/action-nodejs-package-info@v1
         id: package

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v4
         with:
-          merge-multiple: true
+          name: prebuilds
       - run: npm pack
       - uses: codex-team/action-nodejs-package-info@v1
         id: package

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,7 @@ jobs:
     needs: ['cpp-lint', 'js-lint']
     strategy:
       matrix:
-        version: [14, 16, 18, 19, 20, 21, 22]
+        version: [16, 18, 19, 20, 21, 22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
     needs: ['cpp-lint', 'js-lint']
     strategy:
       matrix:
-        version: [14, 16, 18, 19, 20, 21, 22]
+        version: [16, 18, 19, 20, 21, 22]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
       prebuild: 'node scripts/prebuild'
       skip: 'linux-arm linux-ia32'
       target-name: 'iastnativemethods'
-      min-node-version: 14
+      min-node-version: 16
 
   cpp-test-libc:
     needs: ['build']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       prebuild: 'node scripts/prebuild'
       skip: 'linux-arm linux-ia32'
       target-name: 'iastnativemethods'
-      min-node-version: 14
+      min-node-version: 16
 
   pack:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v4
         with:
-          merge-multiple: true
+          name: prebuilds
       - run: npm pack
       - uses: codex-team/action-nodejs-package-info@v1
         id: package


### PR DESCRIPTION
### What does this PR do?
dd-trace is not supportnig node 14 anymore, removing builds for it and setting min supported version to node 16.
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Reduce package size. 

