### PR TITLE
Release 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datadog/native-iast-taint-tracking",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@datadog/native-iast-taint-tracking",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@datadog/native-iast-taint-tracking",
   "home": "https://github.com/DataDog/dd-native-iast-taint-tracking-js/blob/main/README.md",
   "repository": "git@github.com:DataDog/dd-native-iast-taint-tracking-js.git",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Datadog IAST tant tracking support for NodeJS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### What does this PR do?

Release 3.0.0

### Motivation

Remove node 14 support and reduce package size.
It is a major release because we are removing support to node 14.