### PR TITLE
Adjust workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,8 @@ jobs:
   cpp-test-libc:
     needs: ['build']
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     strategy:
       matrix:
         debian:
@@ -83,6 +85,8 @@ jobs:
   cpp-test-musl:
     needs: ['build']
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     strategy:
       matrix:
         alpine:
@@ -137,6 +141,8 @@ jobs:
             artifact: darwin-x64
 
     runs-on: ${{ matrix.target.os }}
+    permissions:
+      checks: write
     env:
       NPM_TAINTEDUTILS: true
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -53,6 +53,8 @@ jobs:
   cpp-test-libc:
     needs: ['build']
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     strategy:
       matrix:
         debian:
@@ -77,6 +79,8 @@ jobs:
   cpp-test-musl:
     needs: ['build']
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     strategy:
       matrix:
         alpine:
@@ -158,6 +162,8 @@ jobs:
             artifact: darwin-x64
 
     runs-on: ${{ matrix.target.os }}
+    permissions:
+      checks: write
     env:
       NPM_TAINTEDUTILS: true
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
     needs: pack
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: codex-team/action-nodejs-package-info@v1.1


### PR DESCRIPTION
### What does this PR do?

Set `contents: write` permission for create_release job
Set `checks: write` permission for all the jobs with `junit-report` action

### Motivation

After changing the default workflow permissions in the repo, it is necessary to adjust the permissions in the workflow file.

### Additional Notes

[mikepenz/action-junit-report doc](https://github.com/mikepenz/action-junit-report?tab=readme-ov-file#pr-run-permissions)

[Create release endpoint doc](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release)

### Test

- [Failing workflow](https://github.com/DataDog/dd-native-iast-taint-tracking-js/actions/runs/10611018306/job/29410126119#step:6:63) before applying changes: 
- [Passing workflow](https://github.com/DataDog/dd-native-iast-taint-tracking-js/actions/runs/10615778317/job/29425423410#step:6:63), with changes applied

[APPSEC-54686](https://datadoghq.atlassian.net/browse/APPSEC-54686)

[APPSEC-54686]: https://datadoghq.atlassian.net/browse/APPSEC-54686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ