### PR TITLE
createNewTainted flag for the AddSecureMarksToTaintedString method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ declare module 'datadog-iast-taint-tracking' {
         createTransaction(transactionId: string): string;
         newTaintedString(transactionId: string, original: string, paramName: string, type: string): string;
         newTaintedObject(transactionId: string, original: any, paramName: string, type: string): any;
-        addSecureMarksToTaintedString(transactionId: string, taintedString: string, secureMarks: number): string;
+        addSecureMarksToTaintedString(transactionId: string, taintedString: string, secureMarks: number, createNewTainted?: boolean): string;
         isTainted(transactionId: string, ...args: string[]): boolean;
         getMetrics(transactionId: string, telemetryVerbosity: number): Metrics;
         getRanges(transactionId: string, original: string): NativeTaintedRange[];

--- a/src/tainted/range.h
+++ b/src/tainted/range.h
@@ -11,7 +11,7 @@
 
 namespace iast {
 namespace tainted {
-using secure_marks_t = uint16_t;
+using secure_marks_t = uint32_t;
 class Range {
  public:
     explicit Range(int start, int end, InputInfo *inputInfo, secure_marks_t secureMarks);

--- a/test/js/secure-marks.spec.js
+++ b/test/js/secure-marks.spec.js
@@ -22,7 +22,7 @@ try {
     makeReferenceEqual()
     v8.setFlagsFromString('--no-allow-natives-syntax')
   // eslint-disable-next-line no-empty
-  } catch (e) {}
+  } catch (e) {/* empty */}
 }
 
 describe('Secure marks', function () {

--- a/test/js/secure-marks.spec.js
+++ b/test/js/secure-marks.spec.js
@@ -22,7 +22,7 @@ try {
     makeReferenceEqual()
     v8.setFlagsFromString('--no-allow-natives-syntax')
   // eslint-disable-next-line no-empty
-  } catch (e) {/* empty */}
+  } catch (e) { /* empty */ }
 }
 
 describe('Secure marks', function () {

--- a/test/js/secure-marks.spec.js
+++ b/test/js/secure-marks.spec.js
@@ -6,6 +6,25 @@
 
 const { TaintedUtils } = require('./util')
 const assert = require('assert')
+
+let referenceEqual
+function makeReferenceEqual () {
+  // eslint-disable-next-line no-new-func
+  referenceEqual = new Function('value1', 'value2', 'return %ReferenceEqual(value1, value2)')
+}
+
+try {
+  makeReferenceEqual()
+} catch (e) {
+  try {
+    const v8 = require('v8')
+    v8.setFlagsFromString('--allow-natives-syntax')
+    makeReferenceEqual()
+    v8.setFlagsFromString('--no-allow-natives-syntax')
+  // eslint-disable-next-line no-empty
+  } catch (e) {}
+}
+
 describe('Secure marks', function () {
   const id = TaintedUtils.createTransaction('666')
   const value = 'test'
@@ -117,11 +136,49 @@ describe('Secure marks', function () {
     const originalTaintedValue = TaintedUtils.newTaintedString(id, 'range1TOREPLACErange2', param, 'REQUEST')
     const taintedValueWithSecureMarks = TaintedUtils.addSecureMarksToTaintedString(id, originalTaintedValue, 0xffaf)
     const taintedValueWithSecureMarks2 =
-      TaintedUtils.addSecureMarksToTaintedString(id, originalTaintedValue, 0xffaff) // over the limit
+      TaintedUtils.addSecureMarksToTaintedString(id, originalTaintedValue, 0x1ffffffff) // over the limit
 
     const markedRanges1 = TaintedUtils.getRanges(id, taintedValueWithSecureMarks)
     const markedRanges2 = TaintedUtils.getRanges(id, taintedValueWithSecureMarks2)
     assert.equal(markedRanges1[0].secureMarks, 0xffaf)
-    assert.equal(markedRanges2[0].secureMarks, 0xfaff)
+    assert.equal(markedRanges2[0].secureMarks, 0xffffffff)
+  })
+
+  describe('createNewTainted flag', () => {
+    it('when false no new tainted should be created', () => {
+      const originalTaintedValue = TaintedUtils.newTaintedString(id, 'tainted', param, 'REQUEST')
+      const taintedWithSecureMarks = TaintedUtils.addSecureMarksToTaintedString(id, originalTaintedValue, 0b1, false)
+
+      assert(referenceEqual(originalTaintedValue, taintedWithSecureMarks))
+
+      const markedRanges1 = TaintedUtils.getRanges(id, originalTaintedValue)
+      const markedRanges2 = TaintedUtils.getRanges(id, taintedWithSecureMarks)
+      assert.equal(markedRanges1[0].secureMarks, 0b1)
+      assert.equal(markedRanges2[0].secureMarks, 0b1)
+    })
+
+    it('when undefined new tainted should be created', () => {
+      const originalTaintedValue = TaintedUtils.newTaintedString(id, 'tainted', param, 'REQUEST')
+      const taintedWithSecureMarks = TaintedUtils.addSecureMarksToTaintedString(id, originalTaintedValue, 0b1)
+
+      const markedRanges1 = TaintedUtils.getRanges(id, originalTaintedValue)
+      const markedRanges2 = TaintedUtils.getRanges(id, taintedWithSecureMarks)
+      assert.equal(markedRanges1[0].secureMarks, 0)
+      assert.equal(markedRanges2[0].secureMarks, 0b1)
+
+      assert(!referenceEqual(originalTaintedValue, taintedWithSecureMarks))
+    })
+
+    it('when true new tainted should be created', () => {
+      const originalTaintedValue = TaintedUtils.newTaintedString(id, 'tainted', param, 'REQUEST')
+      const taintedWithSecureMarks = TaintedUtils.addSecureMarksToTaintedString(id, originalTaintedValue, 0b1, true)
+
+      const markedRanges1 = TaintedUtils.getRanges(id, originalTaintedValue)
+      const markedRanges2 = TaintedUtils.getRanges(id, taintedWithSecureMarks)
+      assert.equal(markedRanges1[0].secureMarks, 0)
+      assert.equal(markedRanges2[0].secureMarks, 0b1)
+
+      assert(!referenceEqual(originalTaintedValue, taintedWithSecureMarks))
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?

- Add the new `createNewTainted` argument to `AddSecureMarksToTaintedString` method:
  - If its value is `undefined` or `true` `AddSecureMarksToTaintedString` will continue creating a new tainted with the secure marks.
  - If `false` the method will update the tainted with the new marks
 - Redefine `secure_marks_t` as `uint32_t` to allow more secure marks as we need one for each vulnerability type and some more.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass

