### PR TITLE
Support Node.js v24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     needs: ['cpp-lint', 'js-lint']
     strategy:
       matrix:
-        version: [16, 17, 18, 19, 20, 21, 22, 23]
+        version: [18, 19, 20, 21, 22, 23, 24]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -28,7 +28,7 @@ jobs:
     needs: ['cpp-lint', 'js-lint']
     strategy:
       matrix:
-        version: [16, 17, 18, 19, 20, 21, 22, 23]
+        version: [18, 19, 20, 21, 22, 23, 24]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -52,7 +52,7 @@ jobs:
       prebuild: 'node scripts/prebuild'
       skip: 'linux-arm,linux-ia32'
       target-name: 'iastnativemethods'
-      min-node-version: 16
+      min-node-version: 18
 
   cpp-test-libc:
     needs: ['build']

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -48,7 +48,7 @@ jobs:
       prebuild: 'node scripts/prebuild'
       skip: 'linux-arm,linux-ia32'
       target-name: 'iastnativemethods'
-      min-node-version: 16
+      min-node-version: 18
 
   cpp-test-libc:
     needs: ['build']

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,7 @@ jobs:
     needs: ['cpp-lint', 'js-lint']
     strategy:
       matrix:
-        version: [16, 18, 19, 20, 21, 22, 23]
+        version: [18, 19, 20, 21, 22, 23, 24]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
     needs: ['cpp-lint', 'js-lint']
     strategy:
       matrix:
-        version: [16, 18, 19, 20, 21, 22, 23]
+        version: [18, 19, 20, 21, 22, 23, 24]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       prebuild: 'node scripts/prebuild'
       skip: 'linux-arm,linux-ia32'
       target-name: 'iastnativemethods'
-      min-node-version: 16
+      min-node-version: 18
 
   pack:
     needs: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ file(GLOB SOURCE_FILES
 
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES} ${CMAKE_JS_SRC})
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
-add_definitions("-DNODE_VERSION_v16")
+add_definitions("-DNODE_VERSION_v18")
 target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB})
 
 # Include N-API wrappers


### PR DESCRIPTION
### What does this PR do?

Update GH workflows with supported Node.js versions

### Motivation

Ensuring support for Node.js v 24

