### PR TITLE
Configure dependabot to update pinned GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/.github/workflows/*"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5
+    groups:
+      gh-actions-packages:
+        patterns:
+          - "*"
+    labels:
+      - dependabot
+      - dependencies
+      - github_actions
+    open-pull-requests-limit: 10


### PR DESCRIPTION
### What does this PR do?

Configure Dependabot or Renovate to receive weekly update PRs when new versions are available.

### Additional Notes

Following instructions from SDLC Security: https://github.com/DataDog/dd-native-iast-taint-tracking-js/pull/133


