### PR TITLE
Add skill to check Node.js major compatibility

### DIFF
--- a/.agents/skills/check-node-compat/SKILL.md
+++ b/.agents/skills/check-node-compat/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: check-node-compat
+description: |
+  Check compatibility with a new Node.js major version for this native C++ addon.
+  Use when a new Node.js major is released and needs to be added to the supported
+  matrix, or when asked to verify whether the addon works on a specific Node version.
+  Triggers: "add Node X support", "does this work on Node X", "new Node major",
+  "update Node version matrix", "Node compatibility".
+---
+
+# Node.js Compatibility Check Skill
+
+## Goal
+
+Determine what changes are needed to support a new Node.js major version in this
+native C++ addon. The addon uses raw V8 APIs directly — there is no abstraction
+layer shielding it from breaking changes. `nan` and `node-addon-api` are present
+only as header path providers for the build system, not as API wrappers.
+
+This means the V8 API scan is the highest-risk step. Everything else is mechanical.
+
+The output is a concrete report: what is safe, what needs a mechanical change, and
+what needs manual verification or a new CI run.
+
+## Step 1 — Identify the new V8 version
+
+Each Node.js major embeds a specific V8 version. Find it with a web search:
+
+```
+Node.js X.0.0 release notes V8 version
+```
+
+Or check the official Node.js changelog at `https://nodejs.org/en/blog/release/`.
+Record the V8 version (e.g., `V8 13.0`). This is the input to Step 2.
+
+See [references/research-sources.md](references/research-sources.md) for additional
+sources to find the exact V8 version embedded in a given Node release.
+
+## Step 2 — Scan for raw V8 API changes (highest risk)
+
+The source uses V8 APIs directly with no abstraction layer. Any V8 API rename,
+removal, or signature change in the new version is a direct build break.
+
+**2a. Find existing version guards:**
+```sh
+grep -rn "NODE_VERSION_v" src/
+```
+
+For each guard found, check whether the API it wraps has changed in the new V8
+version. See [references/repo-compat-surface.md](references/repo-compat-surface.md)
+for the current guards and what they protect.
+
+**2b. Find direct V8 API calls most likely to change between versions:**
+```sh
+# V8 String API (historically the most volatile area in this codebase)
+grep -rn "v8::String::\|->IsExternal\|->IsString\|ExternalString\|NewFromUtf8\|Utf8Value" src/
+
+# V8 Isolate and context API
+grep -rn "GetIsolate\(\)\|GetCurrentContext\(\)\|isolate->Get\|isolate->Throw" src/
+```
+
+These are the V8 API families that have changed most frequently across Node majors.
+Cross-reference hits against the V8 API diff for the old→new version:
+`https://github.com/v8/v8/compare/OLD.V-lkgr...NEW.V-lkgr`
+Focus on changes under `include/` — those are the public API surface.
+
+Web search template for a specific function:
+```
+V8 API "<function_name>" deprecated OR removed OR changed vNEW
+```
+
+See [references/research-sources.md](references/research-sources.md) for V8 diff
+and changelog sources.
+
+## Step 3 — Check header path providers
+
+`nan` and `node-addon-api` are not API abstraction layers in this codebase — they
+are used only to resolve the path to Node.js headers at build time:
+
+- `binding.gyp` uses `require('nan')` to locate Node headers for node-gyp
+- `CMakeLists.txt` uses `require('node-addon-api').include` for the CppUTest build
+
+The check here is minimal: activate the new Node version (e.g. `nvm use X`), then
+run both build steps to confirm headers resolve correctly:
+
+```sh
+npm run build          # node-gyp build — uses nan for headers
+npm run test:native    # CppUTest build — uses node-addon-api for headers
+```
+
+If CppUTest is not installed locally, skip `npm run test:native` and rely on CI
+to surface any header resolution failure for that path.
+
+No API compatibility research is needed for these packages.
+
+If either command fails with a header resolution error, upgrade the offending
+package to a pinned stable version:
+
+```sh
+# Find the latest stable version
+npm view nan version
+npm view node-addon-api version
+
+# Pin the version explicitly in package.json, then install
+npm install nan@X.Y.Z
+# or
+npm install node-addon-api@X.Y.Z
+```
+
+Do not use `@latest` — versions must be pinned.
+
+## Step 4 — Update the hardcoded version define in CMakeLists.txt
+
+[CMakeLists.txt](../../../CMakeLists.txt) contains `-DNODE_VERSION_v18`, which
+drives the `#if defined(...)` guards found in Step 2.
+
+- If Step 2 found no new API changes: no update needed — the current `else` branch
+  already covers the new version.
+- If Step 2 found a new API change requiring a new branch: add
+  `#if defined(NODE_VERSION_vX)` in `src/iast_node.h` and update the define in
+  `CMakeLists.txt`. Always update both files in the same commit.
+
+**Cleaning up obsolete guards:** if the lowest version in the CI matrix has advanced
+past the version a guard was written for (e.g., `NODE_VERSION_v16` once Node 16 is
+removed from the matrix), the guard and its older branch are dead code. Remove them
+and simplify the macro to the surviving branch. Do this in a dedicated cleanup commit,
+not mixed with the new version addition.
+
+See [references/repo-compat-surface.md](references/repo-compat-surface.md) for the
+full picture of this define and the current guards.
+
+## Step 5 — Update the CI version matrix
+
+Add the new Node version to the test matrices in
+[.github/workflows/build.yml](../../../.github/workflows/build.yml).
+
+See [references/repo-compat-surface.md](references/repo-compat-surface.md) for
+which specific jobs have version matrices and which have fixed pinned versions.
+
+## Step 6 — Produce the compatibility report
+
+```
+## Node X Compatibility Report
+
+### V8 API scan
+- Guards found: <list from grep, or "none">
+- Unguarded V8 calls reviewed: <count reviewed>
+- Status per guard/call: <safe / needs new branch / unknown>
+  Reason: <what changed in V8 X.Y, or "no change found in changelog">
+
+### Obsolete guards
+- <guard name>: obsolete since Node <Y> was removed from the matrix — <action: remove / keep>
+- (or: none detected)
+
+### Build system (nan / node-addon-api)
+- Header resolution: OK / FAILED (upgrade needed)
+- Action: none / upgrade <package> to X.Y.Z
+
+### CMakeLists.txt
+- NODE_VERSION define: <current> — <action: no change / update to NODE_VERSION_vX>
+
+### CI Matrix (.github/workflows/build.yml)
+- Jobs updated: <list>
+
+### Verdict
+SAFE TO ADD / NEEDS CHANGES / REQUIRES MANUAL VERIFICATION
+```
+
+Mark REQUIRES MANUAL VERIFICATION if any V8 API call could not be confirmed safe
+from changelog research alone. State what the CI run will surface.
+
+## What this skill cannot guarantee
+
+The definitive answer comes from running CI against the new Node version. Because
+the code uses raw V8 APIs, a breaking change can exist without any changelog entry
+if it was an undocumented internal. The green CI run on the new version is the
+final sign-off.

--- a/.agents/skills/check-node-compat/references/repo-compat-surface.md
+++ b/.agents/skills/check-node-compat/references/repo-compat-surface.md
@@ -1,0 +1,108 @@
+# Repo Compatibility Surface
+
+This document lists every file in this repo that is sensitive to Node.js version
+changes and must be checked or updated when adding a new major.
+
+---
+
+## 1. `src/iast_node.h` — V8 API version guard
+
+The only current version guard in the C++ source:
+
+```c
+#if defined(NODE_VERSION_v16)
+#define IS_EXTERNAL()   IsExternalTwoByte()
+#else
+#define IS_EXTERNAL()   IsExternal()
+#endif
+```
+
+**What it protects:** In Node 16, V8 required `IsExternalTwoByte()` to test whether
+a string uses an external resource. Node 17 unified this under `IsExternal()`.
+
+**Pattern for new versions:** If a future V8 version renames or removes `IsExternal()`,
+a new `#if defined(NODE_VERSION_vX)` branch is needed here. The define is set at
+build time via `CMakeLists.txt`.
+
+**Grep to find all guards:**
+```sh
+grep -rn "NODE_VERSION_v\|IsExternal\|IsExternalTwoByte" src/
+```
+
+---
+
+## 2. `CMakeLists.txt` — hardcoded version define
+
+```cmake
+add_definitions("-DNODE_VERSION_v18")
+```
+
+This define is passed to the C++ compiler and selects which API branch the guards
+in `src/iast_node.h` compile against. The `else` branch (no define, or any define
+other than `NODE_VERSION_v16`) represents the current default V8 API behavior.
+
+**When to update:** Only when a new V8 API change requires a new branch in
+`src/iast_node.h`. If the new Node version is covered by the existing `else` branch,
+no change is needed here — the define does not need to track the Node version number.
+
+**How to update:** Add a conditional block or replace with the new version define.
+Update `src/iast_node.h` in the same commit.
+
+---
+
+## 3. `.github/workflows/build.yml` — CI version matrices
+
+Every job that runs tests against a Node version matrix must be updated.
+
+Verify the current matrix with:
+```sh
+grep -A2 "matrix:" .github/workflows/build.yml
+```
+
+Example current matrix:
+```yaml
+matrix:
+  version: [18, 19, 20, 21, 22, 23, 24, 25, 26]
+```
+
+**Jobs with version matrices (search with `grep -n "version:" .github/workflows/build.yml`):**
+- `valgrind` — runs `test:js-valgrind` across all Node versions
+- `asan` — runs `test:asan` + `test:js-asan` across all Node versions
+
+**Other version references (not a matrix, but fixed):**
+- `js-lint` and `check-licenses` jobs pin `node-version: '20'` — these do not need
+  updating when adding a new major.
+- `pack` job pins `node-version: '18'` for packaging — does not need updating.
+
+**Action:** Add the new version number to the `version: [...]` arrays in the
+`valgrind` and `asan` jobs only.
+
+---
+
+## 4. `package.json` — nan and node-addon-api as header path providers
+
+```json
+"nan": "^2.27.0",
+"node-addon-api": "^4.3.0"
+```
+
+**Neither is an API abstraction layer.** The C++ source uses raw V8 APIs directly
+(`#include <node.h>`, `#include <v8.h>`) with no `Nan::` or N-API calls anywhere in
+`src/`. These packages are used exclusively to resolve the path to Node.js headers
+at build time:
+
+- `binding.gyp` calls `require('nan')` to get the Node headers directory for node-gyp
+- `CMakeLists.txt` calls `require('node-addon-api').include` for the CppUTest build
+
+**Compatibility check:** both packages must be able to resolve headers for the new
+Node version. If `npm run build` or `npm run test:native` fails with a header
+resolution error, follow the pinned upgrade instructions in Step 3 of SKILL.md.
+No V8 API compatibility research is needed for these packages themselves.
+
+---
+
+## 5. `binding.gyp` — no version-specific content
+
+`binding.gyp` does not reference Node version numbers. The NAN include resolves
+dynamically at build time. No changes expected here unless `nan`'s package
+structure changes.

--- a/.agents/skills/check-node-compat/references/research-sources.md
+++ b/.agents/skills/check-node-compat/references/research-sources.md
@@ -1,0 +1,59 @@
+# Research Sources for Node.js Compatibility
+
+Quick reference for finding V8 compatibility information. Note: `nan` and
+`node-addon-api` are used only as header path providers in this repo — they are
+not API abstraction layers. V8 API research is the primary concern.
+
+---
+
+## Node.js release information
+
+**Official release blog** (V8 version per Node release):
+`https://nodejs.org/en/blog/release/vX.0.0`
+Look for the line: *"V8 X.Y"* in the highlights section.
+
+**Node.js changelog on GitHub:**
+`https://github.com/nodejs/node/blob/main/CHANGELOG.md`
+Filter by the target major version tag.
+
+**Node.js deps/v8 directory** (exact V8 version embedded):
+`https://github.com/nodejs/node/tree/vX.0.0/deps/v8`
+The `include/v8-version.h` file contains `V8_MAJOR_VERSION` and `V8_MINOR_VERSION`.
+
+---
+
+## V8 API changes
+
+**V8 API diff between two versions:**
+`https://github.com/v8/v8/compare/X.Y-lkgr...A.B-lkgr`
+Replace `X.Y` and `A.B` with the old and new V8 version numbers (e.g., `12.9-lkgr...13.0-lkgr`).
+Focus on changes to files under `include/` — those are the public API.
+
+**V8 deprecation notices** (searching for a specific function):
+Web search: `site:github.com/v8/v8 "IsExternal" deprecated`
+Or browse: `https://github.com/v8/v8/commits/main/include/v8-string.h`
+
+**V8 blog** (major API changes are announced here):
+`https://v8.dev/blog`
+
+---
+
+## nan and node-addon-api (header path providers)
+
+These packages are not researched for API compatibility — they only need to resolve
+Node.js headers correctly for the new version. For upgrade instructions (including
+how to pin versions correctly), see Step 3 of SKILL.md.
+
+For reference only (not required for a standard compat check):
+- NAN releases: `https://github.com/nodejs/nan/releases`
+- node-addon-api CHANGELOG: `https://github.com/nodejs/node-addon-api/blob/main/CHANGELOG.md`
+
+---
+
+## Quick search templates
+
+| What to find | How to find it |
+|---|---|
+| V8 version in Node X | Web search: `Node.js X.0.0 release V8 version` |
+| Specific V8 API change | Web search: `V8 "<api_name>" removed OR deprecated site:github.com/v8/v8` |
+| V8 String API commit history | Browse: `https://github.com/v8/v8/commits/main/include/v8-string.h` |


### PR DESCRIPTION
### What does this PR do?

Adds a new `check-node-compat` skill under `.agents/skills/check-node-compat/` to guide AI agents through the process of verifying and adding support for a new Node.js major version.

The skill covers:
- Identifying the V8 version embedded in a new Node release
- Scanning raw V8 API usage in `src/` for breaking changes (the highest-risk step)
- Verifying header path providers (`nan`, `node-addon-api`)
- Updating the hardcoded version define in `CMakeLists.txt` and cleaning up obsolete guards
- Updating the CI version matrix
- Producing a structured compatibility report

### Motivation

Each time a new Node.js major is released, a compatibility check is needed to ensure the addon builds and runs correctly.